### PR TITLE
Add FastAPI career assessment MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+career.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-"# AI Genome Career Map" 
+# AI Genome Career Map
+
+This repository contains a minimal FastAPI web application that serves as an AI-powered career assessment MVP.
+
+## Features
+
+- Homepage with dark mode design
+- Step-by-step survey of 15 questions
+- Answers stored in a local SQLite database per user session
+- Result page shows a chart and job recommendations
+
+## Running the Application
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start the server:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+3. Open `http://localhost:8000` in your browser.
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,165 @@
+from fastapi import FastAPI, Request, Form, Cookie, Response
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+import sqlite3
+from uuid import uuid4
+from typing import Optional
+
+# Initialize FastAPI app
+app = FastAPI()
+
+# Mount static files for CSS and JS
+app.mount('/static', StaticFiles(directory='static'), name='static')
+
+# Set up Jinja2 templates
+templates = Jinja2Templates(directory='templates')
+
+# Database initialization
+DB_PATH = 'career.db'
+
+# List of survey questions (15 total)
+QUESTIONS = [
+    "I enjoy working with numbers and data analysis.",
+    "I prefer hands-on tasks over theoretical ones.",
+    "I like helping people solve their problems.",
+    "I enjoy creative writing or artistic endeavors.",
+    "I am comfortable speaking in front of groups.",
+    "I prefer working independently rather than in teams.",
+    "I am interested in how machines or software work.",
+    "I stay calm under pressure.",
+    "I like organizing events or managing projects.",
+    "I pay attention to small details in tasks.",
+    "I enjoy learning new technologies.",
+    "I have an entrepreneurial mindset.",
+    "I prefer structured environments and schedules.",
+    "I enjoy solving puzzles and complex problems.",
+    "I like reading about psychology or human behavior."
+]
+
+TOTAL_QUESTIONS = len(QUESTIONS)
+
+
+def init_db():
+    """Create the responses table if it does not exist."""
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        """CREATE TABLE IF NOT EXISTS responses (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT,
+                q_index INTEGER,
+                answer TEXT
+            )"""
+    )
+    conn.commit()
+    conn.close()
+
+
+# Initialize database on startup
+init_db()
+
+
+@app.get('/', response_class=HTMLResponse)
+async def index(request: Request):
+    """Render homepage."""
+    return templates.TemplateResponse('index.html', {'request': request})
+
+
+@app.get('/survey', response_class=HTMLResponse)
+async def get_survey(request: Request, q: int = 0, session_id: Optional[str] = Cookie(None)):
+    """Display survey question by index."""
+    if session_id is None:
+        session_id = str(uuid4())
+    if q >= TOTAL_QUESTIONS:
+        return RedirectResponse(url='/result', status_code=302)
+    question = QUESTIONS[q]
+    progress = int((q / TOTAL_QUESTIONS) * 100)
+    response = templates.TemplateResponse(
+        'survey.html',
+        {
+            'request': request,
+            'question': question,
+            'q_index': q,
+            'total': TOTAL_QUESTIONS,
+            'progress': progress
+        }
+    )
+    response.set_cookie('session_id', session_id)
+    return response
+
+
+@app.post('/survey')
+async def post_survey(
+    request: Request,
+    q_index: int = Form(...),
+    answer: str = Form(...),
+    session_id: Optional[str] = Cookie(None)
+):
+    """Store answer and redirect to next question."""
+    if session_id is None:
+        session_id = str(uuid4())
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        'INSERT INTO responses (session_id, q_index, answer) VALUES (?, ?, ?)',
+        (session_id, q_index, answer)
+    )
+    conn.commit()
+    conn.close()
+    next_q = int(q_index) + 1
+    if next_q >= TOTAL_QUESTIONS:
+        return RedirectResponse(url='/result', status_code=302)
+    return RedirectResponse(url=f'/survey?q={next_q}', status_code=302)
+
+
+@app.get('/result', response_class=HTMLResponse)
+async def result(request: Request, session_id: Optional[str] = Cookie(None)):
+    """Generate and display result report."""
+    if session_id is None:
+        return RedirectResponse(url='/', status_code=302)
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        'SELECT q_index, answer FROM responses WHERE session_id = ? ORDER BY q_index',
+        (session_id,)
+    )
+    rows = c.fetchall()
+    conn.close()
+    if len(rows) < TOTAL_QUESTIONS:
+        return RedirectResponse(url='/survey', status_code=302)
+
+    # Simple scoring: count positive answers for different categories
+    numeric_answers = [int(r[1]) for r in rows]
+    tech = sum(numeric_answers[i] for i in [0, 6, 10, 13])
+    people = sum(numeric_answers[i] for i in [2, 4, 7, 14])
+    creative = sum(numeric_answers[i] for i in [3, 9, 11])
+    management = sum(numeric_answers[i] for i in [8, 12])
+
+    recommendations = []
+    if tech >= max(people, creative, management):
+        recommendations.append('Consider careers in data science, software engineering, or AI research.')
+    if people >= max(tech, creative, management):
+        recommendations.append('Roles like counseling, HR, or education might suit you.')
+    if creative >= max(tech, people, management):
+        recommendations.append('Look into writing, design, or marketing careers.')
+    if management >= max(tech, people, creative):
+        recommendations.append('Project management or operations could be a good fit.')
+    if not recommendations:
+        recommendations.append('Explore interdisciplinary roles that combine multiple interests.')
+
+    chart_data = {
+        'labels': ['Tech', 'People', 'Creative', 'Management'],
+        'scores': [tech, people, creative, management]
+    }
+
+    return templates.TemplateResponse(
+        'result.html',
+        {
+            'request': request,
+            'chart_data': chart_data,
+            'recommendations': recommendations,
+            'session_id': session_id
+        }
+    )
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+jinja2
+python-multipart

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,41 @@
+body {
+    background-color: #121212;
+    color: #fff;
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+}
+.container {
+    max-width: 800px;
+    margin: auto;
+    padding: 20px;
+    text-align: center;
+}
+.button {
+    display: inline-block;
+    background-color: #4e79a7;
+    color: #fff;
+    padding: 10px 20px;
+    margin: 10px;
+    text-decoration: none;
+    border-radius: 4px;
+}
+.progress-bar {
+    background: #333;
+    border-radius: 4px;
+    margin-bottom: 10px;
+}
+.progress {
+    height: 10px;
+    background: #76b7b2;
+    border-radius: 4px;
+}
+.options label {
+    display: block;
+    margin: 5px 0;
+}
+@media (max-width: 600px) {
+    .container {
+        padding: 10px;
+    }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI Career Assessment</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+<div class="container">
+    {% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>AI-Powered Career Assessment</h1>
+<p>Discover careers that match your personality and interests.</p>
+<a href="/survey" class="button">Start Assessment</a>
+{% endblock %}

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Your Career Assessment Results</h2>
+<canvas id="resultChart" width="400" height="200"></canvas>
+<ul>
+{% for rec in recommendations %}
+  <li>{{ rec }}</li>
+{% endfor %}
+</ul>
+<a href="/survey" class="button">Retake Assessment</a>
+<a href="/result?session={{ session_id }}" class="button">Share Results</a>
+<script>
+const data = {{ chart_data | tojson }};
+const ctx = document.getElementById('resultChart').getContext('2d');
+new Chart(ctx, {
+    type: 'bar',
+    data: {
+        labels: data.labels,
+        datasets: [{
+            label: 'Scores',
+            data: data.scores,
+            backgroundColor: ['#4e79a7','#f28e2b','#e15759','#76b7b2']
+        }]
+    },
+    options: { responsive: true }
+});
+</script>
+{% endblock %}

--- a/templates/survey.html
+++ b/templates/survey.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Question {{ q_index + 1 }} of {{ total }}</h2>
+<div class="progress-bar">
+  <div class="progress" style="width: {{ progress }}%"></div>
+</div>
+<form method="post" action="/survey">
+  <p>{{ question }}</p>
+  <input type="hidden" name="q_index" value="{{ q_index }}">
+  <div class="options">
+    {% for i in range(1,6) %}
+    <label>
+      <input type="radio" name="answer" value="{{ i }}" required> {{ i }}
+    </label>
+    {% endfor %}
+  </div>
+  <button type="submit" class="button">Next</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- build a FastAPI web app with survey and results pages
- add Jinja2 templates and static CSS for dark mode
- store responses in SQLite and display recommendations with Chart.js
- provide requirements and usage in README

## Testing
- `python3 -m pip install -r requirements.txt`
- `uvicorn app.main:app --port 8000 --log-level warning --timeout-keep-alive 1` (terminated immediately)

------
https://chatgpt.com/codex/tasks/task_e_684ae16dbdd88329ba1c3bae4d180e35