### PR TITLE
Change default port to 9999

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ This repository contains a minimal FastAPI web application that serves as an AI-
    ```bash
    pip install -r requirements.txt
    ```
-2. Start the server:
+2. Start the server (the application listens on port `9999` by default):
    ```bash
-   uvicorn app.main:app --reload
+   uvicorn app.main:app --reload --port 9999
    ```
-3. Open `http://localhost:8000` in your browser.
+   Alternatively you can simply run `python app/main.py`.
+3. Open `http://localhost:9999` in your browser.
 

--- a/app/main.py
+++ b/app/main.py
@@ -34,3 +34,7 @@ async def community(request: Request):
 @app.get('/partners', response_class=HTMLResponse)
 async def partners(request: Request):
     return templates.TemplateResponse('06_partners.html', {'request': request})
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=9999)


### PR DESCRIPTION
## Summary
- serve the FastAPI app on port 9999 by default
- update README instructions for the new port

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684aee1574488329ab5099660b9b60f1