### PR TITLE
Fix static path for local execution

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,10 +2,13 @@ from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
 
 app = FastAPI()
-app.mount('/static', StaticFiles(directory='static'), name='static')
-templates = Jinja2Templates(directory='templates')
+app.mount('/static', StaticFiles(directory=BASE_DIR / 'static'), name='static')
+templates = Jinja2Templates(directory=BASE_DIR / 'templates')
 
 @app.get('/', response_class=HTMLResponse)
 async def home(request: Request):


### PR DESCRIPTION
## Summary
- mount `static` and `templates` using absolute paths
- ensure the FastAPI app works when run from any directory

## Testing
- `pytest -q`
- `python app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_684aeecabcec8329ac8c1f2e4977d5ea