### PR TITLE
Implement report pipeline scaffolding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    paths:
+      - 'my_career_report/**/*.json'
+      - 'my_career_report/charts/**'
+      - 'my_career_report/templates/**'
+      - 'my_career_report/generate_report.py'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: pip install -r my_career_report/requirements.txt
+      - name: Generate report
+        run: python my_career_report/generate_report.py
+      - name: Upload PDF
+        uses: actions/upload-artifact@v3
+        with:
+          name: report
+          path: my_career_report/dist/report.pdf
+

--- a/my_career_report/README.md
+++ b/my_career_report/README.md
@@ -1,0 +1,24 @@
+# my_career_report
+
+This project generates automated career reports using data files and Jinja2 templates.
+
+## Structure
+
+- `config.yaml` – output locations and chart settings
+- `data/` – sample input data
+- `charts/` – chart rendering modules
+- `templates/` – Jinja2 templates and CSS assets
+- `utils/` – helper modules for loading data, rendering HTML and exporting PDF
+
+## Install & Run
+
+```bash
+pip install -r requirements.txt
+python generate_report.py
+```
+
+This will create `dist/report.html` and `dist/report.pdf`.
+
+## Continuous Integration
+
+The GitHub Actions workflow in `.github/workflows/ci.yml` installs dependencies and runs `generate_report.py` on each push. The generated PDF is uploaded as a workflow artifact.

--- a/my_career_report/charts/big5_chart.py
+++ b/my_career_report/charts/big5_chart.py
@@ -2,9 +2,11 @@
 import os
 import matplotlib.pyplot as plt
 
-def render_big5(data, output_path, cfg):
-    labels = ['E', 'A', 'C', 'N', 'O']
-    scores = [data['big5'][k] for k in labels]
+
+def render_big5(data: dict, output_path: str, cfg: dict) -> None:
+    """Render BIG-5 bar chart and save to ``output_path``."""
+    labels = ["E", "A", "C", "N", "O"]
+    scores = [data["big5"][k] for k in labels]
     dpi = cfg['charts'].get('dpi', 300)
     figsize = cfg['charts'].get('figsize', [6,4])
     plt.figure(figsize=figsize, dpi=dpi)

--- a/my_career_report/charts/other_charts.py
+++ b/my_career_report/charts/other_charts.py
@@ -1,5 +1,29 @@
 # File: charts/other_charts.py
+"""Stubs for additional chart rendering functions."""
 
-def placeholder():
-    """Placeholder for future chart functions."""
+from typing import Dict
+
+
+def render_interest(data: Dict, output_path: str, cfg: Dict) -> None:
+    """Render the job interest chart to ``output_path``."""
+    pass
+
+
+def render_values(data: Dict, output_path: str, cfg: Dict) -> None:
+    """Render the personal values chart to ``output_path``."""
+    pass
+
+
+def render_ai(data: Dict, output_path: str, cfg: Dict) -> None:
+    """Render the AI skills chart to ``output_path``."""
+    pass
+
+
+def render_tech(data: Dict, output_path: str, cfg: Dict) -> None:
+    """Render the technical competency chart to ``output_path``."""
+    pass
+
+
+def render_soft(data: Dict, output_path: str, cfg: Dict) -> None:
+    """Render the soft skills chart to ``output_path``."""
     pass

--- a/my_career_report/config.yaml
+++ b/my_career_report/config.yaml
@@ -2,8 +2,13 @@ output:
   html: "dist/report.html"
   pdf:  "dist/report.pdf"
 styles:
-  css: "templates/assets/style.css"
+  css:  "templates/assets/style.css"
 charts:
-  big5:    "charts/output/big5.png"
-  dpi:     300
+  big5:     "charts/output/big5.png"
+  interest: "charts/output/interest.png"
+  values:   "charts/output/values.png"
+  ai:       "charts/output/ai.png"
+  tech:     "charts/output/tech.png"
+  soft:     "charts/output/soft.png"
+  dpi:      300
   figsize: [6,4]

--- a/my_career_report/generate_report.py
+++ b/my_career_report/generate_report.py
@@ -6,27 +6,46 @@ from utils.loader import load_data
 from utils.renderer import render_html
 from utils.exporter import html_to_pdf
 from charts.big5_chart import render_big5
+from charts.other_charts import (
+    render_interest,
+    render_values,
+    render_ai,
+    render_tech,
+    render_soft,
+)
 
-CONFIG_PATH = 'config.yaml'
-DATA_PATH = 'data/sample_input.json'
+BASE_DIR = os.path.dirname(__file__)
+CONFIG_PATH = os.path.join(BASE_DIR, 'config.yaml')
+DATA_PATH = os.path.join(BASE_DIR, 'data/sample_input.json')
 
 
 def main():
     with open(CONFIG_PATH, 'r', encoding='utf-8') as f:
         cfg = yaml.safe_load(f)
 
+    # Resolve relative paths based on project directory
+    cfg['output']['html'] = os.path.join(BASE_DIR, cfg['output']['html'])
+    cfg['output']['pdf'] = os.path.join(BASE_DIR, cfg['output']['pdf'])
+    for key in ['big5', 'interest', 'values', 'ai', 'tech', 'soft']:
+        cfg['charts'][key] = os.path.join(BASE_DIR, cfg['charts'][key])
+
     data = load_data(DATA_PATH)
 
-    os.makedirs('dist', exist_ok=True)
-    os.makedirs('charts/output', exist_ok=True)
+    os.makedirs(os.path.join(BASE_DIR, 'dist'), exist_ok=True)
+    os.makedirs(os.path.join(BASE_DIR, 'charts', 'output'), exist_ok=True)
 
     render_big5(data, cfg['charts']['big5'], cfg)
+    render_interest(data, cfg['charts']['interest'], cfg)
+    render_values(data, cfg['charts']['values'], cfg)
+    render_ai(data, cfg['charts']['ai'], cfg)
+    render_tech(data, cfg['charts']['tech'], cfg)
+    render_soft(data, cfg['charts']['soft'], cfg)
 
     html_path = render_html(data, cfg)
 
     pdf_path = html_to_pdf(html_path, cfg['output']['pdf'])
 
-    print(f'Report generated: {pdf_path}')
+    print(f'Successfully generated PDF report at {pdf_path}')
 
 
 if __name__ == '__main__':

--- a/my_career_report/run_report.sh
+++ b/my_career_report/run_report.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+pip install -r requirements.txt
+python generate_report.py
+echo "Generated HTML at dist/report.html and PDF at dist/report.pdf"

--- a/my_career_report/templates/assets/style.css
+++ b/my_career_report/templates/assets/style.css
@@ -18,3 +18,8 @@ img {
     max-width: 100%;
     height: auto;
 }
+
+@media print {
+    body { font-size: 12pt; }
+    table { page-break-inside: avoid; }
+}

--- a/my_career_report/utils/exporter.py
+++ b/my_career_report/utils/exporter.py
@@ -2,7 +2,7 @@
 from weasyprint import HTML
 
 
-def html_to_pdf(html_path, output_pdf):
-    """Convert HTML file to PDF using WeasyPrint."""
+def html_to_pdf(html_path: str, output_pdf: str) -> str:
+    """Convert an HTML file to PDF and return the PDF path."""
     HTML(html_path).write_pdf(output_pdf)
     return output_pdf

--- a/my_career_report/utils/loader.py
+++ b/my_career_report/utils/loader.py
@@ -3,8 +3,8 @@ import json
 import yaml
 
 
-def load_data(path):
-    """Load JSON or YAML file and return data as dict."""
+def load_data(path: str) -> dict:
+    """Load a JSON or YAML file and return a dictionary."""
     with open(path, 'r', encoding='utf-8') as f:
         if path.endswith('.json'):
             return json.load(f)

--- a/my_career_report/utils/renderer.py
+++ b/my_career_report/utils/renderer.py
@@ -1,11 +1,13 @@
 # File: utils/renderer.py
 import os
+from pathlib import Path
 from jinja2 import Environment, FileSystemLoader
 
 
-def render_html(data, cfg):
-    """Render the report HTML using Jinja2."""
-    env = Environment(loader=FileSystemLoader('templates'))
+def render_html(data: dict, cfg: dict) -> str:
+    """Render the report HTML using Jinja2 templates."""
+    project_root = Path(__file__).resolve().parents[1]
+    env = Environment(loader=FileSystemLoader(project_root / 'templates'))
     template = env.get_template('report.html')
     html = template.render(**data, styles=cfg['styles'], charts=cfg['charts'])
     output_path = cfg['output']['html']


### PR DESCRIPTION
## Summary
- expand project configuration
- add stubs for additional chart renderers
- improve utilities with type hints and path handling
- create GitHub Actions workflow for CI
- provide README and run script

## Testing
- `pip install -r my_career_report/requirements.txt`
- `python my_career_report/generate_report.py` *(fails: TemplateNotFound / profile undefined)*

------
https://chatgpt.com/codex/tasks/task_e_685231a111108329b6bdeb56df5c72c3