### PR TITLE
Add WeasyPrint dependency notes

### DIFF
--- a/my_career_report/README.md
+++ b/my_career_report/README.md
@@ -19,6 +19,18 @@ python generate_report.py
 
 This will create `dist/report.html` and `dist/report.pdf`.
 
+### WeasyPrint dependencies
+
+WeasyPrint relies on external libraries such as **cairo** and **Pango**. On
+Linux these are typically available through your package manager (for example
+`apt-get install libpangocairo-1.0-0 libcairo2`).
+
+On Windows you must install the bundled dependencies from the
+[WeasyPrint documentation](https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#installation).
+If you see an error about `libgobject-2.0-0` when running the script, it means
+these libraries are missing. Installing the official WeasyPrint binaries or the
+MSYS2 packages will resolve the issue.
+
 ## Continuous Integration
 
 The GitHub Actions workflow in `.github/workflows/ci.yml` installs dependencies and runs `generate_report.py` on each push. The generated PDF is uploaded as a workflow artifact.


### PR DESCRIPTION
## Summary
- document WeasyPrint dependencies so the script works on Windows and Linux

## Testing
- `pip install -r requirements.txt`
- `python generate_report.py`


------
https://chatgpt.com/codex/tasks/task_e_68523cda98008329aeed2d4b954c6528