### PR TITLE
Add matplotlib chart rendering module

### DIFF
--- a/my_career_report/charts/big5_chart.py
+++ b/my_career_report/charts/big5_chart.py
@@ -1,21 +1,53 @@
 # File: charts/big5_chart.py
+"""Utilities for rendering the BIG-5 personality chart."""
+
 import os
 import matplotlib.pyplot as plt
 
 
 def render_big5(data: dict, output_path: str, cfg: dict) -> None:
-    """Render BIG-5 bar chart and save to ``output_path``."""
+    """Render a BIG-5 bar chart and save it as a PNG.
+
+    Parameters
+    ----------
+    data : dict
+        Either a dictionary with BIG-5 scores ``{"E": .., "A": .., ...}`` or a
+        parent dictionary containing the ``"big5"`` key.
+    output_path : str
+        File path where the chart image will be saved.
+    cfg : dict
+        Configuration dictionary loaded from ``config.yaml``. The keys
+        ``cfg["charts"]["dpi"]`` and ``cfg["charts"]["figsize"]`` control figure
+        size and resolution.
+    """
+
+    big5_data = data.get("big5", data)
     labels = ["E", "A", "C", "N", "O"]
-    scores = [data["big5"][k] for k in labels]
-    dpi = cfg['charts'].get('dpi', 300)
-    figsize = cfg['charts'].get('figsize', [6,4])
-    plt.figure(figsize=figsize, dpi=dpi)
-    plt.bar(labels, scores, color='skyblue')
-    plt.ylim(0, 100)
-    plt.title('BIG-5 Scores')
-    plt.xlabel('Trait')
-    plt.ylabel('Score')
+    scores = [big5_data[label] for label in labels]
+
+    dpi = cfg["charts"].get("dpi", 300)
+    figsize = tuple(cfg["charts"].get("figsize", [6, 4]))
+
+    fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
+    bars = ax.bar(labels, scores, edgecolor="black", alpha=0.8)
+    ax.set_ylim(0, 100)
+    ax.set_title("BIG-5 개인성향 점수", fontsize=14, fontweight="bold")
+    ax.set_xlabel("성향 요인", fontsize=12)
+    ax.set_ylabel("점수 (Index)", fontsize=12)
+    ax.grid(axis="y", linestyle="--", alpha=0.5)
+
+    for bar in bars:
+        height = bar.get_height()
+        ax.text(
+            bar.get_x() + bar.get_width() / 2,
+            height + 1,
+            f"{height:.1f}",
+            ha="center",
+            va="bottom",
+            fontsize=10,
+        )
+
     plt.tight_layout()
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
-    plt.savefig(output_path, dpi=dpi)
-    plt.close()
+    fig.savefig(output_path, bbox_inches="tight")
+    plt.close(fig)

--- a/my_career_report/charts/other_charts.py
+++ b/my_career_report/charts/other_charts.py
@@ -1,29 +1,185 @@
 # File: charts/other_charts.py
-"""Stubs for additional chart rendering functions."""
+"""High-visibility bar chart helpers for my_career_report."""
 
-from typing import Dict
+import os
+from typing import Dict, List
+
+import matplotlib.pyplot as plt
+
+
+def _prep_dir(path: str) -> None:
+    """Ensure the output directory exists."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
 
 
 def render_interest(data: Dict, output_path: str, cfg: Dict) -> None:
-    """Render the job interest chart to ``output_path``."""
-    pass
+    """Render RIASEC interest scores as a bar chart."""
+    interest = data.get("interest", data)
+    labels = ["R", "I", "A", "S", "E", "C"]
+    scores = [interest[label] for label in labels]
+
+    dpi = cfg["charts"].get("dpi", 300)
+    figsize = tuple(cfg["charts"].get("figsize", [6, 4]))
+
+    fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
+    bars = ax.bar(labels, scores, edgecolor="black", alpha=0.8)
+    ax.set_ylim(0, 100)
+    ax.set_title("직무 관심사(RIASEC) 점수", fontsize=14, fontweight="bold")
+    ax.set_xlabel("RIASEC 유형", fontsize=12)
+    ax.set_ylabel("점수 (Index)", fontsize=12)
+    ax.grid(axis="y", linestyle="--", alpha=0.5)
+    for bar in bars:
+        height = bar.get_height()
+        ax.text(
+            bar.get_x() + bar.get_width() / 2,
+            height + 1,
+            f"{height:.1f}",
+            ha="center",
+            va="bottom",
+            fontsize=10,
+        )
+
+    plt.tight_layout()
+    _prep_dir(output_path)
+    fig.savefig(output_path, bbox_inches="tight")
+    plt.close(fig)
 
 
 def render_values(data: Dict, output_path: str, cfg: Dict) -> None:
-    """Render the personal values chart to ``output_path``."""
-    pass
+    """Render job values as a bar chart."""
+    values = data.get("values", data)
+    labels = ["A", "I", "Rec", "Rel", "S", "W"]
+    scores = [values[label] for label in labels]
+
+    dpi = cfg["charts"].get("dpi", 300)
+    figsize = tuple(cfg["charts"].get("figsize", [6, 4]))
+
+    fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
+    bars = ax.bar(labels, scores, edgecolor="black", alpha=0.8)
+    ax.set_ylim(0, 100)
+    ax.set_title("직업 가치관 점수", fontsize=14, fontweight="bold")
+    ax.set_xlabel("가치관 유형", fontsize=12)
+    ax.set_ylabel("점수 (Index)", fontsize=12)
+    ax.grid(axis="y", linestyle="--", alpha=0.5)
+    for bar in bars:
+        height = bar.get_height()
+        ax.text(
+            bar.get_x() + bar.get_width() / 2,
+            height + 1,
+            f"{height:.1f}",
+            ha="center",
+            va="bottom",
+            fontsize=10,
+        )
+
+    plt.tight_layout()
+    _prep_dir(output_path)
+    fig.savefig(output_path, bbox_inches="tight")
+    plt.close(fig)
 
 
 def render_ai(data: Dict, output_path: str, cfg: Dict) -> None:
-    """Render the AI skills chart to ``output_path``."""
-    pass
+    """Render AI literacy scores as a bar chart."""
+    ai_data = data.get("ai", data)
+    labels = ["EU", "TS", "CE", "AO", "SE", "CB", "ER"]
+    scores = [ai_data[label] for label in labels]
+
+    dpi = cfg["charts"].get("dpi", 300)
+    figsize = tuple(cfg["charts"].get("figsize", [6, 4]))
+
+    fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
+    bars = ax.bar(labels, scores, edgecolor="black", alpha=0.8)
+    ax.set_ylim(0, 100)
+    ax.set_title("AI 활용능력 점수", fontsize=14, fontweight="bold")
+    ax.set_xlabel("역량 영역", fontsize=12)
+    ax.set_ylabel("점수 (Index)", fontsize=12)
+    ax.grid(axis="y", linestyle="--", alpha=0.5)
+    for bar in bars:
+        height = bar.get_height()
+        ax.text(
+            bar.get_x() + bar.get_width() / 2,
+            height + 1,
+            f"{height:.1f}",
+            ha="center",
+            va="bottom",
+            fontsize=10,
+        )
+
+    plt.tight_layout()
+    _prep_dir(output_path)
+    fig.savefig(output_path, bbox_inches="tight")
+    plt.close(fig)
 
 
-def render_tech(data: Dict, output_path: str, cfg: Dict) -> None:
-    """Render the technical competency chart to ``output_path``."""
-    pass
+def render_tech(data: List[Dict], output_path: str, cfg: Dict) -> None:
+    """Render technology competency scores as a bar chart."""
+    tech = data
+    if isinstance(data, dict):
+        tech = data.get("tech", [])
+
+    labels = [item["name"] for item in tech]
+    scores = [item["score"] for item in tech]
+
+    dpi = cfg["charts"].get("dpi", 300)
+    figsize = tuple(cfg["charts"].get("figsize", [6, 4]))
+
+    fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
+    bars = ax.bar(labels, scores, edgecolor="black", alpha=0.8)
+    ax.set_ylim(0, 100)
+    ax.set_title("AI/기술 핵심 역량 점수", fontsize=14, fontweight="bold")
+    ax.set_xlabel("핵심 역량", fontsize=12)
+    ax.set_ylabel("점수 (Index)", fontsize=12)
+    ax.grid(axis="y", linestyle="--", alpha=0.5)
+    plt.setp(ax.get_xticklabels(), rotation=45, ha="right", fontsize=10)
+    for bar in bars:
+        height = bar.get_height()
+        ax.text(
+            bar.get_x() + bar.get_width() / 2,
+            height + 1,
+            f"{height:.1f}",
+            ha="center",
+            va="bottom",
+            fontsize=9,
+        )
+
+    plt.tight_layout()
+    _prep_dir(output_path)
+    fig.savefig(output_path, bbox_inches="tight")
+    plt.close(fig)
 
 
-def render_soft(data: Dict, output_path: str, cfg: Dict) -> None:
-    """Render the soft skills chart to ``output_path``."""
-    pass
+def render_soft(data: List[Dict], output_path: str, cfg: Dict) -> None:
+    """Render soft skill scores as a bar chart."""
+    soft = data
+    if isinstance(data, dict):
+        soft = data.get("soft", [])
+
+    labels = [item["name"] for item in soft]
+    scores = [item["score"] for item in soft]
+
+    dpi = cfg["charts"].get("dpi", 300)
+    figsize = tuple(cfg["charts"].get("figsize", [6, 4]))
+
+    fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
+    bars = ax.bar(labels, scores, edgecolor="black", alpha=0.8)
+    ax.set_ylim(0, 100)
+    ax.set_title("비즈니스·소프트 스킬 점수", fontsize=14, fontweight="bold")
+    ax.set_xlabel("스킬 항목", fontsize=12)
+    ax.set_ylabel("점수 (Index)", fontsize=12)
+    ax.grid(axis="y", linestyle="--", alpha=0.5)
+    plt.setp(ax.get_xticklabels(), rotation=45, ha="right", fontsize=10)
+    for bar in bars:
+        height = bar.get_height()
+        ax.text(
+            bar.get_x() + bar.get_width() / 2,
+            height + 1,
+            f"{height:.1f}",
+            ha="center",
+            va="bottom",
+            fontsize=9,
+        )
+
+    plt.tight_layout()
+    _prep_dir(output_path)
+    fig.savefig(output_path, bbox_inches="tight")
+    plt.close(fig)


### PR DESCRIPTION
## Summary
- implement BIG-5 bar chart rendering
- implement interest, values, AI, tech and soft skill chart helpers

## Testing
- `python -m py_compile my_career_report/charts/*.py`
- `python my_career_report/generate_report.py` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68524543c21c8329bb87f938ac701025