### PR TITLE
Add Chart.js chart image generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Python artifacts
+__pycache__/
+*.pyc
+
+# Node artifacts
+node_modules/
+package-lock.json
+
+# Report outputs
+my_career_report/dist/
+my_career_report/charts/output/

--- a/my_career_report/README.md
+++ b/my_career_report/README.md
@@ -34,3 +34,14 @@ MSYS2 packages will resolve the issue.
 ## Continuous Integration
 
 The GitHub Actions workflow in `.github/workflows/ci.yml` installs dependencies and runs `generate_report.py` on each push. The generated PDF is uploaded as a workflow artifact.
+
+## Chart.js Image Rendering
+
+To create a chart image with Chart.js on Node.js run:
+
+```bash
+npm install
+node charts/render_big5_chartjs.js
+```
+
+This generates `charts/output/big5_chartjs.png` using the data from `data/sample_input.json`.

--- a/my_career_report/charts/render_big5_chartjs.js
+++ b/my_career_report/charts/render_big5_chartjs.js
@@ -1,0 +1,45 @@
+import { ChartJSNodeCanvas } from 'chartjs-node-canvas';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+async function renderBig5(data, outputPath) {
+  const width = 600;
+  const height = 400;
+  const chartJSNodeCanvas = new ChartJSNodeCanvas({ width, height });
+  const big5 = data.big5 || data;
+  const configuration = {
+    type: 'bar',
+    data: {
+      labels: ['E', 'A', 'C', 'N', 'O'],
+      datasets: [{
+        label: 'Score',
+        data: ['E','A','C','N','O'].map(k => big5[k]),
+        backgroundColor: 'rgba(54, 162, 235, 0.5)',
+        borderColor: 'rgb(54, 162, 235)',
+        borderWidth: 1
+      }]
+    },
+    options: {
+      scales: { y: { beginAtZero: true, max: 100 } },
+      plugins: { title: { display: true, text: 'BIG-5 Scores' } }
+    }
+  };
+  const buffer = await chartJSNodeCanvas.renderToBuffer(configuration);
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, buffer);
+}
+
+async function main() {
+  const dataPath = path.join(__dirname, '../data/sample_input.json');
+  const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+  const out = path.join(__dirname, 'output/big5_chartjs.png');
+  await renderBig5(data, out);
+  console.log('Chart saved to', out);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/my_career_report/package.json
+++ b/my_career_report/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "my_career_report",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "chartjs-node-canvas": "^5.0.0",
+    "chart.js": "^4.4.1"
+  }
+}


### PR DESCRIPTION
## Summary
- add `render_big5_chartjs.js` to generate BIG-5 chart image with Chart.js
- document how to run the script
- add Node dependencies and ignore build artifacts

## Testing
- `bash run_report.sh`


------
https://chatgpt.com/codex/tasks/task_e_68524678c75883299fb63a183ed41c34