### PR TITLE
Fix Korean text rendering in charts

### DIFF
--- a/my_career_report/README.md
+++ b/my_career_report/README.md
@@ -19,6 +19,13 @@ python generate_report.py
 
 This will create `dist/report.html` and `dist/report.pdf`.
 
+### Korean fonts
+
+The charts rely on the **Noto Sans CJK** fonts that ship with most Linux
+distributions. `generate_report.py` loads this font at runtime so Korean labels
+render correctly. If the font is missing, the script falls back to other common
+Korean fonts such as NanumGothic or Malgun Gothic when available.
+
 ### WeasyPrint dependencies
 
 WeasyPrint relies on external libraries such as **cairo** and **Pango**. On

--- a/my_career_report/generate_report.py
+++ b/my_career_report/generate_report.py
@@ -5,6 +5,7 @@ import yaml
 from utils.loader import load_data
 from utils.renderer import render_html
 from utils.exporter import html_to_pdf
+from utils.fontconfig import set_korean_font
 from charts.big5_chart import render_big5
 from charts.other_charts import (
     render_interest,
@@ -20,6 +21,7 @@ DATA_PATH = os.path.join(BASE_DIR, 'data/sample_input.json')
 
 
 def main():
+    set_korean_font()
     with open(CONFIG_PATH, 'r', encoding='utf-8') as f:
         cfg = yaml.safe_load(f)
 

--- a/my_career_report/utils/fontconfig.py
+++ b/my_career_report/utils/fontconfig.py
@@ -1,0 +1,26 @@
+import os
+from pathlib import Path
+import matplotlib.pyplot as plt
+from matplotlib import font_manager as fm
+
+
+def set_korean_font() -> None:
+    """Configure Matplotlib to use a Korean font if available."""
+    font_path = Path("/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc")
+    available = {f.name for f in fm.fontManager.ttflist}
+
+    if font_path.exists():
+        fm.fontManager.addfont(str(font_path))
+        font_name = fm.FontProperties(fname=str(font_path)).get_name()
+        plt.rcParams["font.family"] = font_name
+    else:
+        for name in [
+            "Noto Sans CJK KR",
+            "NanumGothic",
+            "Malgun Gothic",
+            "AppleGothic",
+        ]:
+            if name in available:
+                plt.rcParams["font.family"] = name
+                break
+    plt.rcParams["axes.unicode_minus"] = False


### PR DESCRIPTION
## Summary
- configure Matplotlib to use a Korean font
- call the configuration before generating charts
- document the font setup in the report README

## Testing
- `python my_career_report/generate_report.py`

------
https://chatgpt.com/codex/tasks/task_e_68524b83c4988329b65a94128a13346e