### PR TITLE
Switch to Chart.js dataset generation

### DIFF
--- a/my_career_report/README.md
+++ b/my_career_report/README.md
@@ -42,17 +42,8 @@ MSYS2 packages will resolve the issue.
 
 The GitHub Actions workflow in `.github/workflows/ci.yml` installs dependencies and runs `generate_report.py` on each push. The generated PDF is uploaded as a workflow artifact.
 
-## Chart.js Image Rendering
+## Chart.js Data
 
-To create a chart image with Chart.js on Node.js run:
-
-```bash
-npm install
-node charts/render_big5_chartjs.js
-node charts/render_interest_chartjs.js
-```
-
-These commands generate `charts/output/big5_chartjs.png` and
-`charts/output/interest_chartjs.png` using the data from
-`data/sample_input.json`. The BIG-5 chart is rendered as a **polar area**
-chart, while the RIASEC interest chart uses a **radar** chart.
+`generate_report.py` now exports a JSON file with the data needed for the
+Chart.js visualisations. The file is written to `charts/output/chart_data.json`
+and can be used directly in web pages.

--- a/my_career_report/charts/chartjs_data.py
+++ b/my_career_report/charts/chartjs_data.py
@@ -1,0 +1,25 @@
+import json
+import os
+from typing import Dict, List, Any
+
+
+def generate_chartjs_data(data: Dict[str, Any], output_path: str) -> str:
+    """Generate a JSON file with Chart.js-friendly data."""
+    dataset = {
+        "big5": data.get("big5", {}),
+        "interest": data.get("interest", {}),
+        "values": data.get("values", {}),
+        "ai": data.get("ai", {}),
+        "tech": {
+            "labels": [item["name"] for item in data.get("tech", [])],
+            "scores": [item["score"] for item in data.get("tech", [])],
+        },
+        "soft": {
+            "labels": [item["name"] for item in data.get("soft", [])],
+            "scores": [item["score"] for item in data.get("soft", [])],
+        },
+    }
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(dataset, f, ensure_ascii=False, indent=2)
+    return output_path

--- a/my_career_report/config.yaml
+++ b/my_career_report/config.yaml
@@ -4,11 +4,6 @@ output:
 styles:
   css:  "templates/assets/style.css"
 charts:
-  big5:     "charts/output/big5.png"
-  interest: "charts/output/interest.png"
-  values:   "charts/output/values.png"
-  ai:       "charts/output/ai.png"
-  tech:     "charts/output/tech.png"
-  soft:     "charts/output/soft.png"
-  dpi:      300
+  data: "charts/output/chart_data.json"
+  dpi: 300
   figsize: [6,4]

--- a/my_career_report/generate_report.py
+++ b/my_career_report/generate_report.py
@@ -6,14 +6,7 @@ from utils.loader import load_data
 from utils.renderer import render_html
 from utils.exporter import html_to_pdf
 from utils.fontconfig import set_korean_font
-from charts.big5_chart import render_big5
-from charts.other_charts import (
-    render_interest,
-    render_values,
-    render_ai,
-    render_tech,
-    render_soft,
-)
+from charts.chartjs_data import generate_chartjs_data
 
 BASE_DIR = os.path.dirname(__file__)
 CONFIG_PATH = os.path.join(BASE_DIR, 'config.yaml')
@@ -28,20 +21,15 @@ def main():
     # Resolve relative paths based on project directory
     cfg['output']['html'] = os.path.join(BASE_DIR, cfg['output']['html'])
     cfg['output']['pdf'] = os.path.join(BASE_DIR, cfg['output']['pdf'])
-    for key in ['big5', 'interest', 'values', 'ai', 'tech', 'soft']:
-        cfg['charts'][key] = os.path.join(BASE_DIR, cfg['charts'][key])
+    cfg['charts']['data'] = os.path.join(BASE_DIR, cfg['charts']['data'])
 
     data = load_data(DATA_PATH)
 
     os.makedirs(os.path.join(BASE_DIR, 'dist'), exist_ok=True)
     os.makedirs(os.path.join(BASE_DIR, 'charts', 'output'), exist_ok=True)
 
-    render_big5(data, cfg['charts']['big5'], cfg)
-    render_interest(data, cfg['charts']['interest'], cfg)
-    render_values(data, cfg['charts']['values'], cfg)
-    render_ai(data, cfg['charts']['ai'], cfg)
-    render_tech(data, cfg['charts']['tech'], cfg)
-    render_soft(data, cfg['charts']['soft'], cfg)
+
+    generate_chartjs_data(data, cfg['charts']['data'])
 
     html_path = render_html(data, cfg)
 


### PR DESCRIPTION
## Summary
- remove unused Matplotlib chart rendering in `generate_report.py`
- add `chartjs_data.py` to export JSON for Chart.js
- simplify `config.yaml` to use a single dataset path
- document Chart.js data output in README

## Testing
- `pip install -q -r requirements.txt`
- `python generate_report.py`

------
https://chatgpt.com/codex/tasks/task_e_6852677878588329a7d72bc0aa2a4554