### PR TITLE
Fix PDF charts and improve readability

### DIFF
--- a/my_career_report/config.yaml
+++ b/my_career_report/config.yaml
@@ -7,3 +7,4 @@ charts:
   data: "charts/output/chart_data.json"
   dpi: 300
   figsize: [6,4]
+  images: "charts/output"

--- a/my_career_report/generate_report.py
+++ b/my_career_report/generate_report.py
@@ -7,6 +7,14 @@ from utils.renderer import render_html
 from utils.exporter import html_to_pdf
 from utils.fontconfig import set_korean_font
 from charts.chartjs_data import generate_chartjs_data
+from charts.big5_chart import render_big5
+from charts.other_charts import (
+    render_interest,
+    render_values,
+    render_ai,
+    render_tech,
+    render_soft,
+)
 
 BASE_DIR = os.path.dirname(__file__)
 CONFIG_PATH = os.path.join(BASE_DIR, 'config.yaml')
@@ -22,14 +30,36 @@ def main():
     cfg['output']['html'] = os.path.join(BASE_DIR, cfg['output']['html'])
     cfg['output']['pdf'] = os.path.join(BASE_DIR, cfg['output']['pdf'])
     cfg['charts']['data'] = os.path.join(BASE_DIR, cfg['charts']['data'])
+    cfg['charts']['images'] = os.path.join(BASE_DIR, cfg['charts'].get('images', 'charts/output'))
+
+    chart_dir = cfg['charts']['images']
+    os.makedirs(chart_dir, exist_ok=True)
+
+    chart_paths = {
+        'big5': os.path.join(chart_dir, 'big5.png'),
+        'interest': os.path.join(chart_dir, 'interest.png'),
+        'values': os.path.join(chart_dir, 'values.png'),
+        'ai': os.path.join(chart_dir, 'ai.png'),
+        'tech': os.path.join(chart_dir, 'tech.png'),
+        'soft': os.path.join(chart_dir, 'soft.png'),
+    }
 
     data = load_data(DATA_PATH)
 
     os.makedirs(os.path.join(BASE_DIR, 'dist'), exist_ok=True)
-    os.makedirs(os.path.join(BASE_DIR, 'charts', 'output'), exist_ok=True)
 
+    # Create static chart images for the PDF
+    render_big5(data, chart_paths['big5'], cfg)
+    render_interest(data, chart_paths['interest'], cfg)
+    render_values(data, chart_paths['values'], cfg)
+    render_ai(data, chart_paths['ai'], cfg)
+    render_tech(data, chart_paths['tech'], cfg)
+    render_soft(data, chart_paths['soft'], cfg)
 
     generate_chartjs_data(data, cfg['charts']['data'])
+
+    # Provide chart image paths to the template
+    cfg['charts']['images'] = chart_paths
 
     html_path = render_html(data, cfg)
 

--- a/my_career_report/templates/assets/style.css
+++ b/my_career_report/templates/assets/style.css
@@ -1,7 +1,11 @@
 /* File: templates/assets/style.css */
 body {
     font-family: Arial, sans-serif;
+    font-size: 14px;
+    line-height: 1.6;
+    letter-spacing: 0.03em;
     margin: 20px;
+    color: #222;
 }
 table {
     width: 100%;
@@ -14,6 +18,18 @@ th, td {
 }
 h1, h2 {
     text-align: center;
+    color: #2b5797;
+}
+
+th {
+    background-color: #f0f4f8;
+}
+
+.chart-img {
+    display: none;
+}
+.chart-canvas {
+    display: block;
 }
 
 .report-section {
@@ -31,4 +47,6 @@ img {
 @media print {
     body { font-size: 12pt; }
     table { page-break-inside: avoid; }
+    .chart-canvas { display: none; }
+    .chart-img { display: block; }
 }

--- a/my_career_report/templates/report.html
+++ b/my_career_report/templates/report.html
@@ -15,7 +15,8 @@
   <!-- Ⅰ. 개인성향 BIG5 요인 분석 -->
   <h2>Ⅰ. 개인성향 BIG5 요인 분석</h2>
   <h3>📈 BIG‐5 성향 그래프</h3>
-  <canvas id="big5Chart" width="600" height="400"></canvas>
+  <canvas id="big5Chart" class="chart-canvas" width="600" height="400"></canvas>
+  <img src="{{ charts.images.big5 }}" class="chart-img" alt="BIG5 chart"/>
 
   <section class="report-section">
     <h3>📊 1-1. 검사 결과</h3>
@@ -108,7 +109,8 @@
   <!-- Ⅱ. 직무 관심사 분석 -->
   <h2>Ⅱ. 직무 관심사 분석</h2>
   <h3>📈 직무 관심사 그래프</h3>
-  <canvas id="interestChart" width="600" height="400"></canvas>
+  <canvas id="interestChart" class="chart-canvas" width="600" height="400"></canvas>
+  <img src="{{ charts.images.interest }}" class="chart-img" alt="Interest chart"/>
 
   <section class="report-section">
     <h3>📊 2-1. 검사 결과</h3>
@@ -199,7 +201,8 @@
   <!-- Ⅲ. 직업 가치관 분석 -->
   <h2>Ⅲ. 직업 가치관 분석</h2>
   <h3>📈 직업 가치관 그래프</h3>
-  <canvas id="valuesChart" width="600" height="400"></canvas>
+  <canvas id="valuesChart" class="chart-canvas" width="600" height="400"></canvas>
+  <img src="{{ charts.images.values }}" class="chart-img" alt="Values chart"/>
 
   <section class="report-section">
     <h3>📊 3-1. 검사 결과</h3>
@@ -290,7 +293,8 @@
   <!-- Ⅳ. AI 활용능력 분석 -->
   <h2>Ⅳ. AI 활용능력 분석</h2>
   <h3>📈 AI 활용능력 그래프</h3>
-  <canvas id="aiChart" width="600" height="400"></canvas>
+  <canvas id="aiChart" class="chart-canvas" width="600" height="400"></canvas>
+  <img src="{{ charts.images.ai }}" class="chart-img" alt="AI chart"/>
 
   <section class="report-section">
     <h3>📊 4-1. 검사 결과</h3>
@@ -381,7 +385,8 @@
   <!-- Ⅴ. AI/기술 핵심 역량 분석 -->
   <h2>Ⅴ. AI/기술 핵심 역량 분석</h2>
   <h3>📈 기술 역량 그래프</h3>
-  <canvas id="techChart" width="600" height="400"></canvas>
+  <canvas id="techChart" class="chart-canvas" width="600" height="400"></canvas>
+  <img src="{{ charts.images.tech }}" class="chart-img" alt="Tech chart"/>
 
   <section class="report-section">
     <h3>📊 5-1. 검사 결과</h3>
@@ -472,7 +477,8 @@
   <!-- Ⅵ. 비즈니스·소프트 스킬 분석 -->
   <h2>Ⅵ. 비즈니스·소프트 스킬 분석</h2>
   <h3>📈 소프트 스킬 그래프</h3>
-  <canvas id="softChart" width="600" height="400"></canvas>
+  <canvas id="softChart" class="chart-canvas" width="600" height="400"></canvas>
+  <img src="{{ charts.images.soft }}" class="chart-img" alt="Soft skills chart"/>
 
   <section class="report-section">
     <h3>📊 6-1. 검사 결과</h3>


### PR DESCRIPTION
## Summary
- generate static chart images using Matplotlib
- embed chart images in the HTML for PDF generation
- improve default styling with subtle colors and increased letter spacing
- adjust CSS so charts show in PDF but canvases show on screen

## Testing
- `pip install -r my_career_report/requirements.txt`
- `python my_career_report/generate_report.py`

------
https://chatgpt.com/codex/tasks/task_e_685268af86288329a26c69d90397c3a5