### PR TITLE
Fix PDF charts and left-align titles

### DIFF
--- a/my_career_report/templates/assets/style.css
+++ b/my_career_report/templates/assets/style.css
@@ -34,7 +34,7 @@ th, td {
     padding: 8px;
 }
 h1, h2, h3, h4 {
-    text-align: center;
+    text-align: left;
     color: #2b5797;
     font-family: 'NanumSquare Neo Bold', sans-serif;
     font-weight: bold;

--- a/my_career_report/templates/report.html
+++ b/my_career_report/templates/report.html
@@ -16,6 +16,7 @@
   <h2>Ⅰ. 개인성향 BIG5 요인 분석</h2>
   <h3>📈 BIG‐5 성향 그래프</h3>
   <canvas id="big5Chart" class="chart-canvas" width="600" height="400"></canvas>
+  <img src="{{ charts.images.big5 }}" class="chart-img" width="600" height="400" alt="BIG-5 chart"/>
 
   <section class="report-section">
     <h3>📊 1-1. 검사 결과</h3>
@@ -109,6 +110,7 @@
   <h2>Ⅱ. 직무 관심사 분석</h2>
   <h3>📈 직무 관심사 그래프</h3>
   <canvas id="interestChart" class="chart-canvas" width="600" height="400"></canvas>
+  <img src="{{ charts.images.interest }}" class="chart-img" width="600" height="400" alt="Interest chart"/>
 
   <section class="report-section">
     <h3>📊 2-1. 검사 결과</h3>
@@ -200,6 +202,7 @@
   <h2>Ⅲ. 직업 가치관 분석</h2>
   <h3>📈 직업 가치관 그래프</h3>
   <canvas id="valuesChart" class="chart-canvas" width="600" height="400"></canvas>
+  <img src="{{ charts.images['values'] }}" class="chart-img" width="600" height="400" alt="Values chart"/>
 
   <section class="report-section">
     <h3>📊 3-1. 검사 결과</h3>
@@ -291,6 +294,7 @@
   <h2>Ⅳ. AI 활용능력 분석</h2>
   <h3>📈 AI 활용능력 그래프</h3>
   <canvas id="aiChart" class="chart-canvas" width="600" height="400"></canvas>
+  <img src="{{ charts.images.ai }}" class="chart-img" width="600" height="400" alt="AI chart"/>
 
   <section class="report-section">
     <h3>📊 4-1. 검사 결과</h3>
@@ -382,6 +386,7 @@
   <h2>Ⅴ. AI/기술 핵심 역량 분석</h2>
   <h3>📈 기술 역량 그래프</h3>
   <canvas id="techChart" class="chart-canvas" width="600" height="400"></canvas>
+  <img src="{{ charts.images.tech }}" class="chart-img" width="600" height="400" alt="Tech chart"/>
 
   <section class="report-section">
     <h3>📊 5-1. 검사 결과</h3>
@@ -473,6 +478,7 @@
   <h2>Ⅵ. 비즈니스·소프트 스킬 분석</h2>
   <h3>📈 소프트 스킬 그래프</h3>
   <canvas id="softChart" class="chart-canvas" width="600" height="400"></canvas>
+  <img src="{{ charts.images.soft }}" class="chart-img" width="600" height="400" alt="Soft skills chart"/>
 
   <section class="report-section">
     <h3>📊 6-1. 검사 결과</h3>

--- a/my_career_report/utils/renderer.py
+++ b/my_career_report/utils/renderer.py
@@ -18,7 +18,17 @@ def render_html(data: dict, cfg: dict) -> str:
     styles = dict(cfg['styles'])
     styles['css'] = rel_style
 
-    html = template.render(**data, styles=styles, charts=cfg['charts'])
+    # Convert chart image paths to be relative to the output HTML directory so
+    # that both the browser and WeasyPrint can correctly locate them.
+    charts_cfg = dict(cfg['charts'])
+    if 'images' in charts_cfg:
+        rel_images = {
+            key: os.path.relpath(path, start=os.path.dirname(cfg['output']['html']))
+            for key, path in charts_cfg['images'].items()
+        }
+        charts_cfg['images'] = rel_images
+
+    html = template.render(**data, styles=styles, charts=charts_cfg)
     output_path = cfg['output']['html']
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
     with open(output_path, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
## Summary
- left-align headings in CSS
- include static chart images so they print in the PDF
- resolve chart image paths relative to HTML output

## Testing
- `pip install -r my_career_report/requirements.txt`
- `python my_career_report/generate_report.py`

------
https://chatgpt.com/codex/tasks/task_e_68526d0efe808329aba005800b7cbb39