### PR TITLE
Round floats to one decimal

### DIFF
--- a/my_career_report/generate_report.py
+++ b/my_career_report/generate_report.py
@@ -6,6 +6,7 @@ from utils.loader import load_data
 from utils.renderer import render_html
 from utils.exporter import html_to_pdf
 from utils.fontconfig import set_korean_font
+from utils.rounder import round_floats
 from charts.chartjs_data import generate_chartjs_data
 from charts.big5_chart import render_big5
 from charts.other_charts import (
@@ -45,6 +46,7 @@ def main():
     }
 
     data = load_data(DATA_PATH)
+    data = round_floats(data, 1)
 
     os.makedirs(os.path.join(BASE_DIR, 'dist'), exist_ok=True)
 

--- a/my_career_report/templates/report.html
+++ b/my_career_report/templates/report.html
@@ -29,9 +29,9 @@
         {% for factor in ["E","A","C","N","O"] %}
         <tr>
           <td>{{ factor }}</td>
-          <td>{{ big5[factor] }}</td>
-          <td>{{ big5_norm[factor] }}</td>
-          <td>{{ big5[factor] - big5_norm[factor] }}</td>
+          <td>{{ big5[factor]|round(1) }}</td>
+          <td>{{ big5_norm[factor]|round(1) }}</td>
+          <td>{{ (big5[factor] - big5_norm[factor])|round(1) }}</td>
         </tr>
         {% endfor %}
       </tbody>
@@ -47,7 +47,7 @@
       <tbody>
         {% for factor in ["E","A","C","N","O"] %}
         <tr>
-          <td>{{ factor }} (Δ={{ big5[factor] - big5_norm[factor] }})</td>
+          <td>{{ factor }} (Δ={{ (big5[factor] - big5_norm[factor])|round(1) }})</td>
           <td>{{ insight[factor] }}</td>
           <td>{{ tip[factor] }}</td>
         </tr>
@@ -120,9 +120,9 @@
         {% for t in ["R","I","A","S","E","C"] %}
         <tr>
           <td>{{ t }}</td>
-          <td>{{ interest[t] }}</td>
-          <td>{{ interest_norm[t] }}</td>
-          <td>{{ interest[t] - interest_norm[t] }}</td>
+          <td>{{ interest[t]|round(1) }}</td>
+          <td>{{ interest_norm[t]|round(1) }}</td>
+          <td>{{ (interest[t] - interest_norm[t])|round(1) }}</td>
         </tr>
         {% endfor %}
       </tbody>
@@ -138,7 +138,7 @@
       <tbody>
         {% for t in ["R","I","A","S","E","C"] %}
         <tr>
-          <td>{{ t }} (Δ={{ interest[t] - interest_norm[t] }})</td>
+          <td>{{ t }} (Δ={{ (interest[t] - interest_norm[t])|round(1) }})</td>
           <td>{{ insight.interest[t] }}</td>
           <td>{{ tip.interest[t] }}</td>
         </tr>
@@ -211,9 +211,9 @@
         {% for k in ["A","I","Rec","Rel","S","W"] %}
         <tr>
           <td>{{ k }}</td>
-          <td>{{ values[k] }}</td>
-          <td>{{ values_norm[k] }}</td>
-          <td>{{ values[k] - values_norm[k] }}</td>
+          <td>{{ values[k]|round(1) }}</td>
+          <td>{{ values_norm[k]|round(1) }}</td>
+          <td>{{ (values[k] - values_norm[k])|round(1) }}</td>
         </tr>
         {% endfor %}
       </tbody>
@@ -229,7 +229,7 @@
       <tbody>
         {% for k in ["A","I","Rec","Rel","S","W"] %}
         <tr>
-          <td>{{ k }} (Δ={{ values[k] - values_norm[k] }})</td>
+          <td>{{ k }} (Δ={{ (values[k] - values_norm[k])|round(1) }})</td>
           <td>{{ insight.values[k] }}</td>
           <td>{{ tip.values[k] }}</td>
         </tr>
@@ -302,9 +302,9 @@
         {% for k in ["EU","TS","CE","AO","SE","CB","ER"] %}
         <tr>
           <td>{{ k }}</td>
-          <td>{{ ai[k] }}</td>
-          <td>{{ ai_norm[k] }}</td>
-          <td>{{ ai[k] - ai_norm[k] }}</td>
+          <td>{{ ai[k]|round(1) }}</td>
+          <td>{{ ai_norm[k]|round(1) }}</td>
+          <td>{{ (ai[k] - ai_norm[k])|round(1) }}</td>
         </tr>
         {% endfor %}
       </tbody>
@@ -320,7 +320,7 @@
       <tbody>
         {% for k in ["EU","TS","CE","AO","SE","CB","ER"] %}
         <tr>
-          <td>{{ k }} (Δ={{ ai[k] - ai_norm[k] }})</td>
+          <td>{{ k }} (Δ={{ (ai[k] - ai_norm[k])|round(1) }})</td>
           <td>{{ insight.ai[k] }}</td>
           <td>{{ tip.ai[k] }}</td>
         </tr>
@@ -393,9 +393,9 @@
         {% for item in tech %}
         <tr>
           <td>{{ item.name }}</td>
-          <td>{{ item.score }}</td>
-          <td>{{ item.norm }}</td>
-          <td>{{ item.score - item.norm }}</td>
+          <td>{{ item.score|round(1) }}</td>
+          <td>{{ item.norm|round(1) }}</td>
+          <td>{{ (item.score - item.norm)|round(1) }}</td>
         </tr>
         {% endfor %}
       </tbody>
@@ -483,8 +483,8 @@
       <tbody>  
         {% for s in soft %}  
         <tr>  
-          <td>{{ s.name }}</td>  
-          <td>{{ s.score }}</td>  
+          <td>{{ s.name }}</td>
+          <td>{{ s.score|round(1) }}</td>
         </tr>  
         {% endfor %}  
       </tbody>  

--- a/my_career_report/utils/rounder.py
+++ b/my_career_report/utils/rounder.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+
+def round_floats(obj, ndigits: int = 1):
+    """Recursively round floats within nested data structures."""
+    if isinstance(obj, float):
+        return round(obj, ndigits)
+    if isinstance(obj, dict):
+        return {k: round_floats(v, ndigits) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [round_floats(v, ndigits) for v in obj]
+    return obj


### PR DESCRIPTION
## Summary
- add recursive rounding utility
- round all loaded numeric data to one decimal
- format numeric fields in Jinja templates with one decimal precision

## Testing
- `pip install -r my_career_report/requirements.txt`
- `python my_career_report/generate_report.py`

------
https://chatgpt.com/codex/tasks/task_e_68526da4d9708329a6ac376783a3a342