### PR TITLE
Use Korean labels for BIG-5 charts

### DIFF
--- a/my_career_report/charts/big5_chart.py
+++ b/my_career_report/charts/big5_chart.py
@@ -22,8 +22,10 @@ def render_big5(data: dict, output_path: str, cfg: dict) -> None:
     """
 
     big5_data = data.get("big5", data)
-    labels = ["E", "A", "C", "N", "O"]
-    scores = [big5_data[label] for label in labels]
+    LABEL_MAP = {"E": "외향성", "A": "친화성", "C": "성실성", "N": "신경성", "O": "개방성"}
+    codes = ["E", "A", "C", "N", "O"]
+    labels = [LABEL_MAP[c] for c in codes]
+    scores = [big5_data[c] for c in codes]
 
     dpi = cfg["charts"].get("dpi", 300)
     figsize = tuple(cfg["charts"].get("figsize", [6, 4]))

--- a/my_career_report/charts/render_big5_chartjs.js
+++ b/my_career_report/charts/render_big5_chartjs.js
@@ -10,13 +10,15 @@ async function renderBig5(data, outputPath) {
   const height = 400;
   const chartJSNodeCanvas = new ChartJSNodeCanvas({ width, height });
   const big5 = data.big5 || data;
+  const LABEL_MAP = { E: '외향성', A: '친화성', C: '성실성', N: '신경성', O: '개방성' };
+  const codes = ['E', 'A', 'C', 'N', 'O'];
   const configuration = {
     type: 'polarArea',
     data: {
-      labels: ['E', 'A', 'C', 'N', 'O'],
+      labels: codes.map(c => LABEL_MAP[c]),
       datasets: [{
         label: 'Score',
-        data: ['E', 'A', 'C', 'N', 'O'].map(k => big5[k]),
+        data: codes.map(c => big5[c]),
         backgroundColor: [
           'rgba(255, 99, 132, 0.5)',
           'rgba(54, 162, 235, 0.5)',

--- a/my_career_report/templates/report.html
+++ b/my_career_report/templates/report.html
@@ -18,6 +18,7 @@
 
   <!-- Ⅰ. 개인성향 BIG5 요인 분석 -->
   <h2>Ⅰ. 개인성향 BIG5 요인 분석</h2>
+  {% set factor_labels = {"E":"외향성","A":"친화성","C":"성실성","N":"신경성","O":"개방성"} %}
   <h3>📈 BIG‐5 성향 그래프</h3>
   <canvas id="big5Chart" class="chart-canvas" width="600" height="400"></canvas>
   <img src="{{ charts.images.big5 }}" class="chart-img" width="600" height="400" alt="BIG-5 chart"/>
@@ -33,7 +34,7 @@
       <tbody>
         {% for factor in ["E","A","C","N","O"] %}
         <tr>
-          <td>{{ factor }}</td>
+          <td>{{ factor_labels[factor] }}</td>
           <td>{{ big5[factor]|round(1) }}</td>
           <td>{{ big5_norm[factor]|round(1) }}</td>
           <td>{{ (big5[factor] - big5_norm[factor])|round(1) }}</td>
@@ -52,7 +53,7 @@
       <tbody>
         {% for factor in ["E","A","C","N","O"] %}
         <tr>
-          <td>{{ factor }} (Δ={{ (big5[factor] - big5_norm[factor])|round(1) }})</td>
+          <td>{{ factor_labels[factor] }} (Δ={{ (big5[factor] - big5_norm[factor])|round(1) }})</td>
           <td>{{ insight[factor] }}</td>
           <td>{{ tip[factor] }}</td>
         </tr>
@@ -696,8 +697,9 @@
     const data = JSON.parse(document.getElementById('report-data').textContent);
 
     // Ⅰ. BIG-5 차트
-    const big5Labels = ["외향성","친화성","성실성","신경성","개방성"];
-    const big5Scores = big5Labels.map(k => data.big5[k]);
+    const codes = ['E','A','C','N','O'];
+    const big5Labels = ['외향성','친화성','성실성','신경성','개방성'];
+    const big5Scores = codes.map(k => data.big5[k]);
   new Chart(document.getElementById("big5Chart"), {
     type: 'bar',
     data: { labels: big5Labels, datasets: [{ label: 'Score', data: big5Scores }] },


### PR DESCRIPTION
## Summary
- map BIG-5 codes to Korean labels in matplotlib chart
- apply same mapping when rendering Chart.js charts
- update HTML template so BIG-5 tables and charts use Korean labels

## Testing
- `bash run_report.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852704fdc308329a858cd65c2e02627