### PR TITLE
Render PDF charts with Chart.js

### DIFF
--- a/my_career_report/README.md
+++ b/my_career_report/README.md
@@ -14,6 +14,7 @@ This project generates automated career reports using data files and Jinja2 temp
 
 ```bash
 pip install -r requirements.txt
+npm install --silent
 python generate_report.py
 ```
 
@@ -44,6 +45,6 @@ The GitHub Actions workflow in `.github/workflows/ci.yml` installs dependencies 
 
 ## Chart.js Data
 
-`generate_report.py` now exports a JSON file with the data needed for the
-Chart.js visualisations. The file is written to `charts/output/chart_data.json`
-and can be used directly in web pages.
+`generate_report.py` now renders Chart.js graphs for the PDF by calling a Node
+script. It also exports a JSON file with the data needed for the web version at
+`charts/output/chart_data.json`.

--- a/my_career_report/charts/render_chartjs_images.js
+++ b/my_career_report/charts/render_chartjs_images.js
@@ -1,0 +1,83 @@
+import { ChartJSNodeCanvas } from 'chartjs-node-canvas';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+async function renderCharts(dataPath, outDir) {
+  const width = 600;
+  const height = 400;
+  const canvas = new ChartJSNodeCanvas({ width, height });
+  const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const big5Codes = ['E','A','C','N','O'];
+  const big5Labels = ['외향성','친화성','성실성','신경성','개방성'];
+  const big5Scores = big5Codes.map(k => data.big5[k]);
+  let config = {
+    type: 'bar',
+    data: { labels: big5Labels, datasets: [{ label: 'Score', data: big5Scores }] },
+    options: { scales: { y: { beginAtZero: true, max: 100 } } }
+  };
+  let buffer = await canvas.renderToBuffer(config);
+  fs.writeFileSync(path.join(outDir, 'big5.png'), buffer);
+
+  const interestCodes = ['R','I','A','S','E','C'];
+  const interestLabels = ['현실형','탐구형','예술형','사회형','기업형','관습형'];
+  const interestScores = interestCodes.map(k => data.interest[k]);
+  config = {
+    type: 'bar',
+    data: { labels: interestLabels, datasets: [{ label: 'Score', data: interestScores }] },
+    options: { scales: { y: { beginAtZero: true, max: 100 } } }
+  };
+  buffer = await canvas.renderToBuffer(config);
+  fs.writeFileSync(path.join(outDir, 'interest.png'), buffer);
+
+  const valuesCodes = ['A','I','Rec','Rel','S','W'];
+  const valuesLabels = ['능력발휘','자율성','보상','안정성','사회적 인정','워라밸'];
+  const valuesScores = valuesCodes.map(k => data.values[k]);
+  config = {
+    type: 'radar',
+    data: { labels: valuesLabels, datasets: [{ label: 'Score', data: valuesScores }] },
+    options: { scales: { r: { beginAtZero: true, max: 100 } } }
+  };
+  buffer = await canvas.renderToBuffer(config);
+  fs.writeFileSync(path.join(outDir, 'values.png'), buffer);
+
+  const aiCodes = ['EU','TS','CE','AO','SE','CB','ER'];
+  const aiLabels = ['AI 이해','프롬프트','검증','도구 적용','학습','협업','윤리'];
+  const aiScores = aiCodes.map(k => data.ai[k]);
+  config = {
+    type: 'radar',
+    data: { labels: aiLabels, datasets: [{ label: 'Score', data: aiScores }] },
+    options: { scales: { r: { beginAtZero: true, max: 100 } } }
+  };
+  buffer = await canvas.renderToBuffer(config);
+  fs.writeFileSync(path.join(outDir, 'ai.png'), buffer);
+
+  const techLabels = data.tech.map(t => t.name);
+  const techScores = data.tech.map(t => t.score);
+  config = {
+    type: 'bar',
+    data: { labels: techLabels, datasets: [{ label: 'Score', data: techScores }] },
+    options: { indexAxis: 'y', scales: { x: { beginAtZero: true, max: 100 } } }
+  };
+  buffer = await canvas.renderToBuffer(config);
+  fs.writeFileSync(path.join(outDir, 'tech.png'), buffer);
+
+  const softLabels = data.soft.map(t => t.name);
+  const softScores = data.soft.map(t => t.score);
+  config = {
+    type: 'bar',
+    data: { labels: softLabels, datasets: [{ label: 'Score', data: softScores }] },
+    options: { indexAxis: 'y', scales: { x: { beginAtZero: true, max: 100 } } }
+  };
+  buffer = await canvas.renderToBuffer(config);
+  fs.writeFileSync(path.join(outDir, 'soft.png'), buffer);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const [dataPath, outDir] = process.argv.slice(2);
+  renderCharts(dataPath, outDir).catch(err => { console.error(err); process.exit(1); });
+}

--- a/my_career_report/generate_report.py
+++ b/my_career_report/generate_report.py
@@ -8,14 +8,8 @@ from utils.exporter import html_to_pdf
 from utils.fontconfig import set_korean_font
 from utils.rounder import round_floats
 from charts.chartjs_data import generate_chartjs_data
-from charts.big5_chart import render_big5
-from charts.other_charts import (
-    render_interest,
-    render_values,
-    render_ai,
-    render_tech,
-    render_soft,
-)
+import json
+import subprocess
 
 BASE_DIR = os.path.dirname(__file__)
 CONFIG_PATH = os.path.join(BASE_DIR, 'config.yaml')
@@ -50,13 +44,12 @@ def main():
 
     os.makedirs(os.path.join(BASE_DIR, 'dist'), exist_ok=True)
 
-    # Create static chart images for the PDF
-    render_big5(data, chart_paths['big5'], cfg)
-    render_interest(data, chart_paths['interest'], cfg)
-    render_values(data, chart_paths['values'], cfg)
-    render_ai(data, chart_paths['ai'], cfg)
-    render_tech(data, chart_paths['tech'], cfg)
-    render_soft(data, chart_paths['soft'], cfg)
+    # Create static chart images for the PDF using Chart.js
+    chart_data_tmp = os.path.join(chart_dir, 'chartjs_input.json')
+    with open(chart_data_tmp, 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False)
+    node_script = os.path.join(BASE_DIR, 'charts', 'render_chartjs_images.js')
+    subprocess.run(['node', node_script, chart_data_tmp, chart_dir], check=True)
 
     generate_chartjs_data(data, cfg['charts']['data'])
 

--- a/my_career_report/run_report.sh
+++ b/my_career_report/run_report.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
 pip install -r requirements.txt
+npm install --silent
 python generate_report.py
 echo "Generated HTML at dist/report.html and PDF at dist/report.pdf"


### PR DESCRIPTION
## Summary
- create `render_chartjs_images.js` to generate static Chart.js graphs
- update `generate_report.py` to call the new Node script
- document Node install step in README and update run script

## Testing
- `bash run_report.sh`

------
https://chatgpt.com/codex/tasks/task_e_68527126a3e48329b2fb3d382721fc6d