### PR TITLE
Add radar comparison for Big-5 chart

### DIFF
--- a/my_career_report/charts/chartjs_data.py
+++ b/my_career_report/charts/chartjs_data.py
@@ -7,6 +7,7 @@ def generate_chartjs_data(data: Dict[str, Any], output_path: str) -> str:
     """Generate a JSON file with Chart.js-friendly data."""
     dataset = {
         "big5": data.get("big5", {}),
+        "big5_norm": data.get("big5_norm", {}),
         "interest": data.get("interest", {}),
         "values": data.get("values", {}),
         "ai": data.get("ai", {}),

--- a/my_career_report/charts/render_chartjs_images.js
+++ b/my_career_report/charts/render_chartjs_images.js
@@ -15,10 +15,29 @@ async function renderCharts(dataPath, outDir) {
   const big5Codes = ['E','A','C','N','O'];
   const big5Labels = ['외향성','친화성','성실성','신경성','개방성'];
   const big5Scores = big5Codes.map(k => data.big5[k]);
+  const big5Norm = big5Codes.map(k => (data.big5_norm || {})[k]);
   let config = {
-    type: 'bar',
-    data: { labels: big5Labels, datasets: [{ label: 'Score', data: big5Scores }] },
-    options: { scales: { y: { beginAtZero: true, max: 100 } } }
+    type: 'radar',
+    data: {
+      labels: big5Labels,
+      datasets: [
+        {
+          label: 'Your Score',
+          data: big5Scores,
+          backgroundColor: 'rgba(54, 162, 235, 0.3)',
+          borderColor: 'rgb(54, 162, 235)',
+          borderWidth: 2
+        },
+        {
+          label: 'Global Norm',
+          data: big5Norm,
+          backgroundColor: 'rgba(255, 99, 132, 0.1)',
+          borderColor: 'rgb(255, 99, 132)',
+          borderWidth: 2
+        }
+      ]
+    },
+    options: { scales: { r: { beginAtZero: true, max: 100 } } }
   };
   let buffer = await canvas.renderToBuffer(config);
   fs.writeFileSync(path.join(outDir, 'big5.png'), buffer);

--- a/my_career_report/templates/report.html
+++ b/my_career_report/templates/report.html
@@ -679,6 +679,7 @@
   <script id="report-data" type="application/json">
   {
     "big5": {{ big5 | tojson }},
+    "big5_norm": {{ big5_norm | tojson }},
     "interest": {{ interest | tojson }},
     "values": {{ values | tojson }},
     "ai": {{ ai | tojson }},
@@ -700,10 +701,17 @@
     const codes = ['E','A','C','N','O'];
     const big5Labels = ['외향성','친화성','성실성','신경성','개방성'];
     const big5Scores = codes.map(k => data.big5[k]);
+    const big5Norm = codes.map(k => data.big5_norm[k]);
   new Chart(document.getElementById("big5Chart"), {
-    type: 'bar',
-    data: { labels: big5Labels, datasets: [{ label: 'Score', data: big5Scores }] },
-    options: { scales: { y: { beginAtZero: true, max:100 } } }
+    type: 'radar',
+    data: {
+      labels: big5Labels,
+      datasets: [
+        { label: 'Your Score', data: big5Scores, backgroundColor: 'rgba(54, 162, 235, 0.3)', borderColor: 'rgb(54, 162, 235)', borderWidth: 2 },
+        { label: 'Global Norm', data: big5Norm, backgroundColor: 'rgba(255, 99, 132, 0.1)', borderColor: 'rgb(255, 99, 132)', borderWidth: 2 }
+      ]
+    },
+    options: { scales: { r: { beginAtZero: true, max:100 } } }
   });
 
     // Ⅱ. 직무 관심사 차트


### PR DESCRIPTION
## Summary
- add global norm data to Chart.js dataset
- render Big-5 radar chart comparing personal score vs norm in HTML
- update Node script to generate radar chart image with norm

## Testing
- `pip install -r my_career_report/requirements.txt`
- `npm install --prefix my_career_report --silent`
- `python my_career_report/generate_report.py`

------
https://chatgpt.com/codex/tasks/task_e_6852724fba2883298c756b51f81097e6