### PR TITLE
Improve BIG-5 report layout

### DIFF
--- a/my_career_report/charts/render_chartjs_images.js
+++ b/my_career_report/charts/render_chartjs_images.js
@@ -8,7 +8,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 async function renderCharts(dataPath, outDir) {
   const width = 600;
   const height = 400;
-  const canvas = new ChartJSNodeCanvas({ width, height });
+  const canvas = new ChartJSNodeCanvas({ width, height, chartCallback: (Chart) => { Chart.defaults.font.size = 24; } });
   const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
   fs.mkdirSync(outDir, { recursive: true });
 

--- a/my_career_report/templates/assets/style.css
+++ b/my_career_report/templates/assets/style.css
@@ -49,6 +49,7 @@ th {
 }
 .chart-canvas {
     display: block;
+    margin: 0 auto;
 }
 
 .report-section {
@@ -101,4 +102,20 @@ img {
 
 .page-break {
     page-break-after: always;
+}
+
+/* Alignment for BIG-5 results table */
+.big5-results th:first-child,
+.big5-results td:first-child {
+    text-align: center;
+}
+.big5-results th:not(:first-child),
+.big5-results td:not(:first-child) {
+    text-align: left;
+}
+
+/* Alignment for BIG-5 career table */
+.big5-career th:nth-child(2),
+.big5-career td:nth-child(2) {
+    text-align: center;
 }

--- a/my_career_report/templates/report.html
+++ b/my_career_report/templates/report.html
@@ -25,7 +25,7 @@
 
   <section class="report-section">
     <h3>📊 1-1. 검사 결과</h3>
-    <table>
+    <table class="big5-results">
       <thead>
         <tr>
           <th>Big-5 요인</th><th>Your Score</th><th>Global Norm</th><th>Δ Index</th>
@@ -75,14 +75,20 @@
 
   <section class="report-section">
     <h3>🎯 1-4. 커리어 매칭 (BIG-5 기반)</h3>
-    <table>
+    <table class="big5-career">
       <thead>
         <tr><th>상위 특성 조합</th><th>추천 직무</th><th>추천 사유</th></tr>
       </thead>
       <tbody>
         {% for c in career.big5 %}
         <tr>
-          <td><strong>{{ c.combo }}</strong><br/>({{ c.scores }})</td>
+          <td>
+            <strong>
+              {% for code in c.combo.split('+') %}
+                {{ factor_labels[code] }}{% if not loop.last %}+{% endif %}
+              {% endfor %}
+            </strong>
+          </td>
           <td>{{ c.job }}</td>
           <td>{{ c.reason }}</td>
         </tr>
@@ -696,6 +702,7 @@
 
   <script>
     const data = JSON.parse(document.getElementById('report-data').textContent);
+    Chart.defaults.font.size = 24;
 
     // Ⅰ. BIG-5 차트
     const codes = ['E','A','C','N','O'];


### PR DESCRIPTION
## Summary
- center the graph canvas and enlarge chart fonts
- align cells in the BIG-5 results and career tables
- show personality combos in Korean without scores
- increase chart font size when rendering static images

## Testing
- `python generate_report.py`
- `node charts/render_chartjs_images.js data/sample_input.json charts/output`

------
https://chatgpt.com/codex/tasks/task_e_685277dde3748329852b5b5db047ba57