### PR TITLE
Fix chart paths for portability

### DIFF
--- a/my_career_report/utils/renderer.py
+++ b/my_career_report/utils/renderer.py
@@ -18,17 +18,17 @@ def render_html(data: dict, cfg: dict) -> str:
     styles = dict(cfg['styles'])
     styles['css'] = rel_style
 
-    # Convert chart image paths to ``file://`` URIs so WeasyPrint can always
-    # resolve them regardless of the current working directory.  Using absolute
-    # URIs avoids issues with ``..`` segments that some environments disallow
-    # when loading local files.
+    # Convert chart image paths to be relative to the HTML output.  WeasyPrint
+    # resolves relative URLs based on the HTML file location, so using relative
+    # paths keeps the generated report portable.  The original configuration may
+    # contain absolute paths, so we normalise them here.
     charts_cfg = dict(cfg['charts'])
     if 'images' in charts_cfg:
-        uri_images = {
-            key: Path(path).resolve().as_uri()
+        rel_images = {
+            key: os.path.relpath(path, start=os.path.dirname(cfg['output']['html']))
             for key, path in charts_cfg['images'].items()
         }
-        charts_cfg['images'] = uri_images
+        charts_cfg['images'] = rel_images
 
     html = template.render(**data, styles=styles, charts=charts_cfg)
     output_path = cfg['output']['html']


### PR DESCRIPTION
## Summary
- generate relative paths for chart images so output HTML works anywhere

## Testing
- `pip install -r requirements.txt`
- `npm install --silent`
- `python generate_report.py`

------
https://chatgpt.com/codex/tasks/task_e_68528509b0408329aae163a07bb00061