### PR TITLE
Implement new Chart.js visualizations

### DIFF
--- a/my_career_report/charts/chartjs_data.py
+++ b/my_career_report/charts/chartjs_data.py
@@ -9,11 +9,15 @@ def generate_chartjs_data(data: Dict[str, Any], output_path: str) -> str:
         "big5": data.get("big5", {}),
         "big5_norm": data.get("big5_norm", {}),
         "interest": data.get("interest", {}),
+        "interest_norm": data.get("interest_norm", {}),
         "values": data.get("values", {}),
+        "values_norm": data.get("values_norm", {}),
         "ai": data.get("ai", {}),
+        "ai_norm": data.get("ai_norm", {}),
         "tech": {
             "labels": [item["name"] for item in data.get("tech", [])],
             "scores": [item["score"] for item in data.get("tech", [])],
+            "norms": [item.get("norm") for item in data.get("tech", [])],
         },
         "soft": {
             "labels": [item["name"] for item in data.get("soft", [])],

--- a/my_career_report/charts/render_chartjs_images.js
+++ b/my_career_report/charts/render_chartjs_images.js
@@ -2,6 +2,7 @@ import { ChartJSNodeCanvas } from 'chartjs-node-canvas';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import ChartDataLabels from 'chartjs-plugin-datalabels';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -14,6 +15,7 @@ async function renderCharts(dataPath, outDir) {
     chartCallback: (Chart) => {
       Chart.defaults.font.size = 14;
       Chart.defaults.font.family = 'NanumSquareRound Regular, NanumSquareRound Bold, Arial, sans-serif';
+      Chart.register(ChartDataLabels);
     }
   });
   const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
@@ -53,9 +55,30 @@ async function renderCharts(dataPath, outDir) {
   const interestCodes = ['R','I','A','S','E','C'];
   const interestLabels = ['현실형','탐구형','예술형','사회형','기업형','관습형'];
   const interestScores = interestCodes.map(k => data.interest[k]);
+  const interestNorm = interestCodes.map(k => (data.interest_norm || {})[k]);
   config = {
     type: 'bar',
-    data: { labels: interestLabels, datasets: [{ label: 'Score', data: interestScores }] },
+    data: {
+      labels: interestLabels,
+      datasets: [
+        {
+          label: `${name}님의 점수`,
+          data: interestScores,
+          backgroundColor: 'rgba(54, 162, 235, 0.6)',
+          borderColor: 'rgb(54, 162, 235)',
+          borderWidth: 1,
+          borderRadius: 10
+        },
+        {
+          label: '평균값',
+          data: interestNorm,
+          backgroundColor: 'rgba(255, 99, 132, 0.4)',
+          borderColor: 'rgb(255, 99, 132)',
+          borderWidth: 1,
+          borderRadius: 10
+        }
+      ]
+    },
     options: { scales: { y: { beginAtZero: true, max: 100 } } }
   };
   buffer = await canvas.renderToBuffer(config);
@@ -64,9 +87,28 @@ async function renderCharts(dataPath, outDir) {
   const valuesCodes = ['A','I','Rec','Rel','S','W'];
   const valuesLabels = ['능력발휘','자율성','보상','안정성','사회적 인정','워라밸'];
   const valuesScores = valuesCodes.map(k => data.values[k]);
+  const valuesNorm = valuesCodes.map(k => (data.values_norm || {})[k]);
   config = {
     type: 'radar',
-    data: { labels: valuesLabels, datasets: [{ label: 'Score', data: valuesScores }] },
+    data: {
+      labels: valuesLabels,
+      datasets: [
+        {
+          label: `${name}님의 점수`,
+          data: valuesScores,
+          backgroundColor: 'rgba(54, 162, 235, 0.3)',
+          borderColor: 'rgb(54, 162, 235)',
+          borderWidth: 2
+        },
+        {
+          label: '평균값',
+          data: valuesNorm,
+          backgroundColor: 'rgba(255, 99, 132, 0.1)',
+          borderColor: 'rgb(255, 99, 132)',
+          borderWidth: 2
+        }
+      ]
+    },
     options: { scales: { r: { beginAtZero: true, max: 100 } } }
   };
   buffer = await canvas.renderToBuffer(config);
@@ -76,9 +118,17 @@ async function renderCharts(dataPath, outDir) {
   const aiLabels = ['AI 이해','프롬프트','검증','도구 적용','학습','협업','윤리'];
   const aiScores = aiCodes.map(k => data.ai[k]);
   config = {
-    type: 'radar',
-    data: { labels: aiLabels, datasets: [{ label: 'Score', data: aiScores }] },
-    options: { scales: { r: { beginAtZero: true, max: 100 } } }
+    type: 'polarArea',
+    data: {
+      labels: aiLabels,
+      datasets: [{ data: aiScores, backgroundColor: aiCodes.map(() => 'rgba(54, 162, 235, 0.6)') }]
+    },
+    options: {
+      scales: { r: { beginAtZero: true, max: 100 } },
+      plugins: {
+        datalabels: { color: '#000', anchor: 'center', align: 'center' }
+      }
+    }
   };
   buffer = await canvas.renderToBuffer(config);
   fs.writeFileSync(path.join(outDir, 'ai.png'), buffer);
@@ -87,7 +137,10 @@ async function renderCharts(dataPath, outDir) {
   const techScores = data.tech.map(t => t.score);
   config = {
     type: 'bar',
-    data: { labels: techLabels, datasets: [{ label: 'Score', data: techScores }] },
+    data: {
+      labels: techLabels,
+      datasets: [{ label: 'Score', data: techScores, backgroundColor: 'rgba(54, 162, 235, 0.6)', borderColor: 'rgb(54, 162, 235)', borderWidth: 1, borderRadius: 10 }]
+    },
     options: { indexAxis: 'y', scales: { x: { beginAtZero: true, max: 100 } } }
   };
   buffer = await canvas.renderToBuffer(config);
@@ -96,9 +149,12 @@ async function renderCharts(dataPath, outDir) {
   const softLabels = data.soft.map(t => t.name);
   const softScores = data.soft.map(t => t.score);
   config = {
-    type: 'bar',
-    data: { labels: softLabels, datasets: [{ label: 'Score', data: softScores }] },
-    options: { indexAxis: 'y', scales: { x: { beginAtZero: true, max: 100 } } }
+    type: 'radar',
+    data: {
+      labels: softLabels,
+      datasets: [{ label: 'Score', data: softScores, backgroundColor: 'rgba(54, 162, 235, 0.3)', borderColor: 'rgb(54, 162, 235)', borderWidth: 2 }]
+    },
+    options: { scales: { r: { beginAtZero: true, max: 100 } } }
   };
   buffer = await canvas.renderToBuffer(config);
   fs.writeFileSync(path.join(outDir, 'soft.png'), buffer);

--- a/my_career_report/package.json
+++ b/my_career_report/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "dependencies": {
     "chartjs-node-canvas": "^5.0.0",
-    "chart.js": "^4.4.1"
+    "chart.js": "^4.4.1",
+    "chartjs-plugin-datalabels": "^2.2.0"
   }
 }

--- a/my_career_report/templates/report.html
+++ b/my_career_report/templates/report.html
@@ -6,6 +6,7 @@
   <title>AI 기반 진로 탐색 및 역량 진단 결과 보고서</title>
   <link rel="stylesheet" href="{{ styles.css }}">
   <script src="{{ scripts.chartjs }}"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
 </head>
 <body>
   <div class="cover-page">
@@ -729,9 +730,16 @@
     const interestCodes = ['R','I','A','S','E','C'];
     const interestLabels = ["현실형","탐구형","예술형","사회형","기업형","관습형"];
     const interestScores = interestCodes.map(k => data.interest[k]);
+    const interestNorm = interestCodes.map(k => data.interest_norm[k]);
   new Chart(document.getElementById("interestChart"), {
     type: 'bar',
-    data: { labels: interestLabels, datasets: [{ label: 'Score', data: interestScores }] },
+    data: {
+      labels: interestLabels,
+      datasets: [
+        { label: '{{ name }}님의 점수', data: interestScores, backgroundColor: 'rgba(54, 162, 235, 0.6)', borderColor: 'rgb(54, 162, 235)', borderWidth: 1, borderRadius: 10 },
+        { label: '평균값', data: interestNorm, backgroundColor: 'rgba(255, 99, 132, 0.4)', borderColor: 'rgb(255, 99, 132)', borderWidth: 1, borderRadius: 10 }
+      ]
+    },
     options: { scales: { y: { beginAtZero: true, max:100 } } }
   });
 
@@ -739,9 +747,16 @@
   const valuesCodes = ['A','I','Rec','Rel','S','W'];
   const valuesLabels = ["능력발휘","자율성","보상","안정성","사회적 인정","워라밸"];
   const valuesScores = valuesCodes.map(k => data.values[k]);
+  const valuesNorm = valuesCodes.map(k => data.values_norm[k]);
   new Chart(document.getElementById("valuesChart"), {
     type: 'radar',
-    data: { labels: valuesLabels, datasets: [{ label: 'Score', data: valuesScores }] },
+    data: {
+      labels: valuesLabels,
+      datasets: [
+        { label: '{{ name }}님의 점수', data: valuesScores, backgroundColor: 'rgba(54, 162, 235, 0.3)', borderColor: 'rgb(54, 162, 235)', borderWidth: 2 },
+        { label: '평균값', data: valuesNorm, backgroundColor: 'rgba(255, 99, 132, 0.1)', borderColor: 'rgb(255, 99, 132)', borderWidth: 2 }
+      ]
+    },
     options: { scales: { r: { beginAtZero: true, max:100 } } }
   });
 
@@ -750,9 +765,15 @@
   const aiLabels = ["AI 이해","프롬프트","검증","도구 적용","학습","협업","윤리"];
   const aiScores = aiCodes.map(k => data.ai[k]);
   new Chart(document.getElementById("aiChart"), {
-    type: 'radar',
-    data: { labels: aiLabels, datasets: [{ label: 'Score', data: aiScores }] },
-    options: { scales: { r: { beginAtZero: true, max:100 } } }
+    type: 'polarArea',
+    data: {
+      labels: aiLabels,
+      datasets: [{ data: aiScores, backgroundColor: aiCodes.map(() => 'rgba(54, 162, 235, 0.6)') }]
+    },
+    options: {
+      scales: { r: { beginAtZero: true, max:100 } },
+      plugins: { datalabels: { color: '#000', anchor: 'center', align: 'center' } }
+    }
   });
 
     // Ⅴ. 기술 역량 차트
@@ -760,7 +781,10 @@
   const techScores = data.tech.scores;
   new Chart(document.getElementById("techChart"), {
     type: 'bar',
-    data: { labels: techLabels, datasets: [{ label: 'Score', data: techScores }] },
+    data: {
+      labels: techLabels,
+      datasets: [{ label: 'Score', data: techScores, backgroundColor: 'rgba(54, 162, 235, 0.6)', borderColor: 'rgb(54, 162, 235)', borderWidth: 1, borderRadius: 10 }]
+    },
     options: { indexAxis: 'y', scales: { x: { beginAtZero: true, max:100 } } }
   });
 
@@ -768,9 +792,12 @@
   const softLabels = data.soft.labels;
   const softScores = data.soft.scores;
   new Chart(document.getElementById("softChart"), {
-    type: 'bar',
-    data: { labels: softLabels, datasets: [{ label: 'Score', data: softScores }] },
-    options: { indexAxis: 'y', scales: { x: { beginAtZero: true, max:100 } } }
+    type: 'radar',
+    data: {
+      labels: softLabels,
+      datasets: [{ label: 'Score', data: softScores, backgroundColor: 'rgba(54, 162, 235, 0.3)', borderColor: 'rgb(54, 162, 235)', borderWidth: 2 }]
+    },
+    options: { scales: { r: { beginAtZero: true, max:100 } } }
   });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add datalabel plugin dependency
- output normative scores in chart JSON
- render charts with updated Chart.js config
- include data labels plugin in HTML template

## Testing
- `bash run_report.sh`

------
https://chatgpt.com/codex/tasks/task_e_68529380f5e48329afbad26c06e7e2ab