### PR TITLE
Add dependency check before generating report

### DIFF
--- a/my_career_report/README.md
+++ b/my_career_report/README.md
@@ -20,6 +20,10 @@ python generate_report.py
 
 This will create `dist/report.html` and `dist/report.pdf`.
 
+If you see an error about `chartjs-plugin-datalabels` not being found,
+make sure the Node.js dependencies were installed by running `npm install`
+in the `my_career_report` directory.
+
 ### Korean fonts
 
 The charts rely on the **Noto Sans CJK** fonts that ship with most Linux

--- a/my_career_report/generate_report.py
+++ b/my_career_report/generate_report.py
@@ -45,6 +45,15 @@ def main():
 
     os.makedirs(os.path.join(BASE_DIR, 'dist'), exist_ok=True)
 
+    # Ensure required Node.js packages are installed
+    node_modules = os.path.join(BASE_DIR, 'node_modules')
+    datalabels_pkg = os.path.join(node_modules, 'chartjs-plugin-datalabels')
+    if not os.path.exists(datalabels_pkg):
+        raise RuntimeError(
+            "Node dependencies not found. Please run 'npm install' in the "
+            "my_career_report directory before generating the report."
+        )
+
     # Copy a local copy of Chart.js so the report works offline
     chartjs_src = os.path.join(BASE_DIR, 'node_modules', 'chart.js', 'dist', 'chart.umd.js')
     chartjs_dest = os.path.join(os.path.dirname(cfg['output']['html']), 'chart.js')


### PR DESCRIPTION
## Summary
- check for `chartjs-plugin-datalabels` in `generate_report.py`
- update README with troubleshooting note about missing Node packages

## Testing
- `./run_report.sh`

------
https://chatgpt.com/codex/tasks/task_e_68529587eef48329a0737760e96ded2a