### PR TITLE
Improve interest section localization

### DIFF
--- a/my_career_report/templates/assets/style.css
+++ b/my_career_report/templates/assets/style.css
@@ -116,6 +116,24 @@ img {
     text-align: right;
 }
 
+/* Alignment and layout for interest results table */
+.interest-results {
+    table-layout: fixed;
+}
+.interest-results th,
+.interest-results td {
+    width: 25%;
+}
+.interest-results th {
+    text-align: center;
+}
+.interest-results td:first-child {
+    text-align: center;
+}
+.interest-results td:not(:first-child) {
+    text-align: right;
+}
+
 /* Alignment for BIG-5 career table */
 .big5-career th:first-child,
 .big5-career td:first-child {

--- a/my_career_report/templates/report.html
+++ b/my_career_report/templates/report.html
@@ -124,17 +124,18 @@
   <h3>📈 직무 관심사 그래프</h3>
   <canvas id="interestChart" class="chart-canvas" width="600" height="400"></canvas>
   <img src="{{ charts.images.interest }}" class="chart-img" width="600" height="400" alt="Interest chart"/>
+  {% set interest_labels = {"R":"현실형","I":"탐구형","A":"예술형","S":"사회형","E":"진취형","C":"관습형"} %}
 
   <section class="report-section">
     <h3>📊 2-1. 검사 결과</h3>
-    <table class="insight-tip">
+    <table class="insight-tip interest-results">
       <thead>
-        <tr><th>관심도 타입</th><th>{{ name }}님의 점수</th><th>평균값</th><th>Δ Index</th></tr>
+        <tr><th>직무 관심사</th><th>{{ name }}님의 점수</th><th>평균값</th><th>Δ Index</th></tr>
       </thead>
       <tbody>
         {% for t in ["R","I","A","S","E","C"] %}
         <tr>
-          <td>{{ t }}</td>
+          <td>{{ interest_labels[t] }}</td>
           <td>{{ interest[t]|round(1) }}</td>
           <td>{{ interest_norm[t]|round(1) }}</td>
           <td>{{ (interest[t] - interest_norm[t])|round(1) }}</td>
@@ -154,7 +155,7 @@
       <tbody>
         {% for t in ["R","I","A","S","E","C"] %}
         <tr>
-          <td>{{ t }} (Δ={{ (interest[t] - interest_norm[t])|round(1) }})</td>
+          <td>{{ interest_labels[t] }}</td>
           <td>{{ insight.interest[t] }}</td>
           <td>{{ tip.interest[t] }}</td>
         </tr>
@@ -183,7 +184,13 @@
       <tbody>
         {% for c in career.interest %}
         <tr>
-          <td><strong>{{ c.combo }}</strong><br/>({{ c.scores }})</td>
+          <td>
+            <strong>
+              {% for code in c.combo.split('+') %}
+                {{ interest_labels[code] }}{% if not loop.last %} + {% endif %}
+              {% endfor %}
+            </strong>
+          </td>
           <td>{{ c.job }}</td>
           <td>{{ c.reason }}</td>
         </tr>


### PR DESCRIPTION
## Summary
- localize job interest results in report HTML
- localize quick tips and career matching content
- add CSS class for interest results table layout
- generate report as a test

## Testing
- `bash my_career_report/run_report.sh`

------
https://chatgpt.com/codex/tasks/task_e_68529cfcc7a883298cbfcff7255bc12c