### PR TITLE
Fix values tagline in report template

### DIFF
--- a/my_career_report/templates/report.html
+++ b/my_career_report/templates/report.html
@@ -266,8 +266,8 @@
 
   <section class="report-section">
     <h3>🚀 3-3. Profile Tagline & 주요 역할</h3>
-    <p><strong>Tagline</strong>: {{ profile.values.tagline }}</p>
-    <blockquote>{{ profile.values.summary }}</blockquote>
+    <p><strong>Tagline</strong>: {{ profile['values'].tagline }}</p>
+    <blockquote>{{ profile['values'].summary }}</blockquote>
     <ul>
       {% for r in role['values'] %}
       <li>🎯 <strong>{{ r.name }}</strong>: {{ r.reason }}</li>


### PR DESCRIPTION
## Summary
- fix retrieval of values profile tagline and summary using dict indexing

## Testing
- `bash my_career_report/run_report.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852a2215a0483298fe58783cd1594ed