### PR TITLE
Refine report sections

### DIFF
--- a/my_career_report/templates/report.html
+++ b/my_career_report/templates/report.html
@@ -50,7 +50,7 @@
     <h3>💡 1-2. 인사이트 & Quick Tip</h3>
     <table class="insight-tip">
       <thead>
-        <tr><th>영역</th><th>한줄 인사이트</th><th>Quick Tip</th></tr>
+        <tr><th>직업가치관</th><th>한줄 인사이트</th><th>Quick Tip</th></tr>
       </thead>
       <tbody>
         {% for factor in ["E","A","C","N","O"] %}
@@ -250,12 +250,12 @@
     <h3>💡 3-2. 인사이트 & Quick Tip</h3>
     <table class="insight-tip">
       <thead>
-        <tr><th>영역</th><th>한줄 인사이트</th><th>Quick Tip</th></tr>
+        <tr><th>직업가치관</th><th>한줄 인사이트</th><th>Quick Tip</th></tr>
       </thead>
       <tbody>
         {% for k in ["A","I","Rec","Rel","S","W"] %}
         <tr>
-          <td>{{ values_labels[k] }} (Δ={{ (values[k] - values_norm[k])|round(1) }})</td>
+          <td>{{ values_labels[k] }}</td>
           <td>{{ insight.values[k] }}</td>
           <td>{{ tip.values[k] }}</td>
         </tr>
@@ -289,7 +289,7 @@
               {% for code in c.combo.split('+') %}
                 {{ values_labels[code]|default(code) }}{% if not loop.last %}+{% endif %}
               {% endfor %}
-            </strong><br/>({{ c.scores }})
+            </strong>
           </td>
           <td>{{ c.job }}</td>
           <td>{{ c.reason }}</td>
@@ -350,12 +350,12 @@
     <h3>💡 4-2. 인사이트 & Quick Tip</h3>
     <table class="tech-insight">
       <thead>
-        <tr><th>영역</th><th>한줄 인사이트</th><th>Quick Tip</th></tr>
+        <tr><th>AI 활용능력</th><th>한줄 인사이트</th><th>Quick Tip</th></tr>
       </thead>
       <tbody>
         {% for k in ["EU","TS","CE","AO","SE","CB","ER"] %}
         <tr>
-          <td>{{ ai_labels[k] }} (Δ={{ (ai[k] - ai_norm[k])|round(1) }})</td>
+          <td>{{ ai_labels[k] }}</td>
           <td>{{ insight.ai[k] }}</td>
           <td>{{ tip.ai[k] }}</td>
         </tr>
@@ -389,7 +389,7 @@
               {% for code in c.combo.split('+') %}
                 {{ ai_labels[code]|default(code) }}{% if not loop.last %}+{% endif %}
               {% endfor %}
-            </strong><br/>({{ c.scores }})
+            </strong>
           </td>
           <td>{{ c.job }}</td>
           <td>{{ c.reason }}</td>
@@ -446,7 +446,7 @@
     <h3>💡 5-2. 인사이트 & Quick Tip</h3>
     <table class="tech-insight">
       <thead>
-        <tr><th>역량</th><th>한줄 인사이트</th><th>Quick Tip</th></tr>
+        <tr><th>AI/기술 핵심 역량</th><th>한줄 인사이트</th><th>Quick Tip</th></tr>
       </thead>
       <tbody>
         {% for item in tech %}
@@ -480,7 +480,7 @@
       <tbody>
         {% for c in career.tech %}
         <tr>
-          <td><strong>{{ c.combo }}</strong><br/>({{ c.scores }})</td>
+          <td><strong>{{ c.combo }}</strong></td>
           <td>{{ c.job }}</td>
           <td>{{ c.reason }}</td>
         </tr>
@@ -519,7 +519,7 @@
     <h3>📊 6-1. 검사 결과</h3>
     <table class="soft-results">
       <thead>  
-        <tr><th>역량 항목</th><th>{{ name }}님의 점수</th></tr>
+        <tr><th>비즈니스 역량</th><th>{{ name }}님의 점수</th></tr>
       </thead>  
       <tbody>  
         {% for s in soft %}  
@@ -536,7 +536,7 @@
     <h3>💡 6-2. 인사이트 & Quick Tip</h3>
     <table class="soft-insight">  
       <thead>  
-        <tr><th>역량</th><th>한줄 인사이트</th><th>Quick Tip</th></tr>  
+        <tr><th>비즈니스 역량</th><th>한줄 인사이트</th><th>Quick Tip</th></tr>
       </thead>  
       <tbody>  
         {% for s in soft %}  
@@ -570,7 +570,7 @@
       <tbody>
         {% for c in career.soft %}
         <tr>
-          <td><strong>{{ c.combo }}</strong><br/>({{ c.scores }})</td>
+          <td><strong>{{ c.combo }}</strong></td>
           <td>{{ c.job }}</td>
           <td>{{ c.reason }}</td>
         </tr>


### PR DESCRIPTION
## Summary
- update insight tables with new headers and remove Δ values
- hide combination score labels in career match sections

## Testing
- `bash run_report.sh`
- `python generate_report.py`

------
https://chatgpt.com/codex/tasks/task_e_6852a665f9e88329b512b1345f028889