### PR TITLE
Update CI to install Node deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,15 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
       - name: Install dependencies
-        run: pip install -r my_career_report/requirements.txt
+        run: |
+          pip install -r my_career_report/requirements.txt
+          npm install --silent
+        working-directory: my_career_report
       - name: Generate report
         run: python my_career_report/generate_report.py
       - name: Upload PDF


### PR DESCRIPTION
## Summary
- configure Node with actions/setup-node
- install npm dependencies before running the report generator

## Testing
- `pytest`
- `python my_career_report/generate_report.py`


------
https://chatgpt.com/codex/tasks/task_e_6852e9d3a9e48329abba0371bcbc9a52